### PR TITLE
Feature/21 custom point type

### DIFF
--- a/.github/workflows/ci_builds.yml
+++ b/.github/workflows/ci_builds.yml
@@ -38,14 +38,14 @@ jobs:
         conan --version
     
     - name: "Build: compiled, shared, boost"
-      run: conan create CDT/ -o as_compiled_library=True -o shared=True -o use_boost=True
+      run: conan create CDT/ -o as_compiled_library=True -o shared=True -o use_boost=True --build missing
     - name: "Build: compiled, shared, without boost"
       run: conan create CDT/ -o as_compiled_library=True -o shared=True -o use_boost=False
     - name: "Build: compiled, static, boost"
-      run: conan create CDT/ -o as_compiled_library=True -o use_boost=True
+      run: conan create CDT/ -o as_compiled_library=True -o use_boost=True --build missing
     - name: "Build: compiled, static, without boost"
       run: conan create CDT/ -o as_compiled_library=True -o use_boost=False
     - name: "Build: header-only, boost"
-      run: conan create CDT/ -o use_boost=True
+      run: conan create CDT/ -o use_boost=True --build missing
     - name: "Build: header-only, without boost"
       run: conan create CDT/ -o use_boost=False

--- a/CDT/include/CDT.h
+++ b/CDT/include/CDT.h
@@ -19,6 +19,7 @@
 
 #include <cassert>
 #include <cstdlib>
+#include <iterator>
 #include <limits>
 #include <memory>
 #include <stack>

--- a/CDT/include/CDT.h
+++ b/CDT/include/CDT.h
@@ -87,6 +87,22 @@ public:
         TGetVertexCoord getY);
     /// Insert vertices into triangulation
     void insertVertices(const std::vector<V2d<T> >& vertices);
+    /**
+     * Insert constraints (custom-type fixed edges) into triangulation
+     * @tparam TEdgeIter iterator that dereferences to custom edge type
+     * @tparam TGetEdgeVertex function object getting coordinate from* vertex.
+     * Getter signature: const TEdgeIter::value_type& -> CDT::VertInd
+     * @param first beginning of the range of edges to add
+     * @param last end of the range of edges to add
+     * @param getStart getter of edge start vertex index
+     * @param getEnd getter of edge end vertex index
+     */
+    template <typename TEdgeIter, typename TGetEdgeVertex>
+    void insertEdges(
+        TEdgeIter first,
+        TEdgeIter last,
+        TGetEdgeVertex getStart,
+        TGetEdgeVertex getEnd);
     /// Insert constraints (fixed edges) into triangulation
     void insertEdges(const std::vector<Edge>& edges);
     /// Erase triangles adjacent to super triangle
@@ -357,6 +373,23 @@ void Triangulation<T>::insertVertices(
     typedef typename std::vector<V2d<T> >::const_iterator Cit;
     for(; first != last; ++first)
         insertVertex(V2d<T>::make(getX(*first), getY(*first)));
+}
+
+template <typename T>
+template <typename TEdgeIter, typename TGetEdgeVertex>
+void Triangulation<T>::insertEdges(
+    TEdgeIter first,
+    const TEdgeIter last,
+    TGetEdgeVertex getStart,
+    TGetEdgeVertex getEnd)
+{
+    for(; first != last; ++first)
+    {
+        // +3 to account for super-triangle vertices
+        insertEdge(
+            Edge(VertInd(getStart(*first) + 3), VertInd(getEnd(*first) + 3)));
+    }
+    eraseDummies();
 }
 
 //-----

--- a/CDT/include/CDT.hpp
+++ b/CDT/include/CDT.hpp
@@ -11,7 +11,6 @@
 
 #include "CDTUtils.h"
 #include <algorithm>
-#include <iterator>
 #include <stdexcept>
 
 namespace CDT

--- a/CDT/include/CDT.hpp
+++ b/CDT/include/CDT.hpp
@@ -231,13 +231,7 @@ TriInd Triangulation<T>::addTriangle()
 template <typename T>
 void Triangulation<T>::insertEdges(const std::vector<Edge>& edges)
 {
-    typedef std::vector<Edge>::const_iterator ECit;
-    for(ECit e = edges.begin(); e != edges.end(); ++e)
-    {
-        // +3 to account for super-triangle vertices
-        insertEdge(Edge(VertInd(e->v1() + 3), VertInd(e->v2() + 3)));
-    }
-    eraseDummies();
+    insertEdges(edges.begin(), edges.end(), edge_get_v1, edge_get_v2);
 }
 
 template <typename T>

--- a/CDT/include/CDT.hpp
+++ b/CDT/include/CDT.hpp
@@ -10,8 +10,8 @@
 #include "CDT.h"
 
 #include "remove_at.hpp"
-#include <stdexcept>
 #include <algorithm>
+#include <stdexcept>
 
 #ifdef CDT_CXX11_IS_SUPPORTED
 namespace std
@@ -234,8 +234,9 @@ TriInd Triangulation<T>::addTriangle()
 {
     if(m_dummyTris.empty())
     {
-        const Triangle dummy = {{noVertex, noVertex, noVertex},
-                                {noNeighbor, noNeighbor, noNeighbor}};
+        const Triangle dummy = {
+            {noVertex, noVertex, noVertex},
+            {noNeighbor, noNeighbor, noNeighbor}};
         triangles.push_back(dummy);
         return TriInd(triangles.size() - 1);
     }
@@ -373,8 +374,8 @@ tuple<TriInd, VertInd, VertInd> Triangulation<T>::intersectedTriangle(
 template <typename T>
 void Triangulation<T>::addSuperTriangle(const Box2d<T>& box)
 {
-    const V2d<T> center = {(box.min.x + box.max.x) / T(2),
-                           (box.min.y + box.max.y) / T(2)};
+    const V2d<T> center = {
+        (box.min.x + box.max.x) / T(2), (box.min.y + box.max.y) / T(2)};
     const T w = box.max.x - box.min.x;
     const T h = box.max.y - box.min.y;
     T r = std::sqrt(w * w + h * h) / 2.0; // incircle radius
@@ -387,8 +388,9 @@ void Triangulation<T>::addSuperTriangle(const Box2d<T>& box)
     vertices.push_back(Vertex<T>::make(posV1, TriInd(0)));
     vertices.push_back(Vertex<T>::make(posV2, TriInd(0)));
     vertices.push_back(Vertex<T>::make(posV3, TriInd(0)));
-    const Triangle superTri = {{VertInd(0), VertInd(1), VertInd(2)},
-                               {noNeighbor, noNeighbor, noNeighbor}};
+    const Triangle superTri = {
+        {VertInd(0), VertInd(1), VertInd(2)},
+        {noNeighbor, noNeighbor, noNeighbor}};
     addTriangle(superTri);
 #ifdef CDT_USE_BOOST
     if(m_closestPtMode == FindingClosestPoint::BoostRTree)

--- a/CDT/include/CDTUtils.h
+++ b/CDT/include/CDTUtils.h
@@ -98,8 +98,6 @@ struct CDT_EXPORT V2d
     T x; ///< X-coordinate
     T y; ///< Y-coordinate
 
-    /// Raw address getter to use as plain array T[3]
-    const T* raw() const;
     /// Create vector from X and Y coordinates
     static V2d make(const T x, const T y);
 };

--- a/CDT/include/CDTUtils.h
+++ b/CDT/include/CDTUtils.h
@@ -102,12 +102,14 @@ struct CDT_EXPORT V2d
     static V2d make(const T x, const T y);
 };
 
+/// X- coordinate getter for V2d
 template <typename T>
 const T& getX_V2d(const V2d<T>& v)
 {
     return v.x;
 }
 
+/// Y-coordinate getter for V2d
 template <typename T>
 const T& getY_V2d(const V2d<T>& v)
 {
@@ -203,6 +205,18 @@ struct CDT_EXPORT Edge
 private:
     std::pair<VertInd, VertInd> m_vertices;
 };
+
+/// Get edge first vertex
+inline VertInd edge_get_v1(const Edge& e)
+{
+    return e.v1();
+}
+
+/// Get edge second vertex
+inline VertInd edge_get_v2(const Edge& e)
+{
+    return e.v2();
+}
 
 typedef unordered_set<Edge> EdgeUSet;             ///< Hash table of edges
 typedef unordered_set<TriInd> TriIndUSet;         ///< Hash table of triangles

--- a/CDT/include/CDTUtils.h
+++ b/CDT/include/CDTUtils.h
@@ -102,6 +102,18 @@ struct CDT_EXPORT V2d
     static V2d make(const T x, const T y);
 };
 
+template <typename T>
+const T& getX_V2d(const V2d<T>& v)
+{
+    return v.x;
+}
+
+template <typename T>
+const T& getY_V2d(const V2d<T>& v)
+{
+    return v.y;
+}
+
 /// If two 2D vectors are exactly equal
 template <typename T>
 CDT_EXPORT bool operator==(const CDT::V2d<T>& lhs, const CDT::V2d<T>& rhs)
@@ -135,10 +147,19 @@ struct CDT_EXPORT Box2d
 {
     V2d<T> min; ///< min box corner
     V2d<T> max; ///< max box corner
-
-    /// Bounding box of a collection of 2D points
-    static Box2d envelop(const std::vector<V2d<T> >& vertices);
 };
+
+/// Bounding box of a collection of custom 2D points given coordinate getters
+template <typename T, typename TVertexIter, typename TGetVertexCoord>
+Box2d<T> envelopBox(
+    TVertexIter first,
+    TVertexIter last,
+    TGetVertexCoord getX,
+    TGetVertexCoord getY);
+
+/// Bounding box of a collection of 2D points
+template <typename T>
+Box2d<T> envelopBox(const std::vector<V2d<T> >& vertices);
 
 /// Triangulation vertex
 template <typename T>

--- a/CDT/include/CDTUtils.hpp
+++ b/CDT/include/CDTUtils.hpp
@@ -20,12 +20,6 @@ namespace CDT
 // V2d
 //*****************************************************************************
 template <typename T>
-const T* V2d<T>::raw() const
-{
-    return &x;
-}
-
-template <typename T>
 V2d<T> V2d<T>::make(const T x, const T y)
 {
     V2d<T> out = {x, y};
@@ -156,7 +150,7 @@ PtLineLocation::Enum
 locatePointLine(const V2d<T>& p, const V2d<T>& v1, const V2d<T>& v2)
 {
     using namespace predicates::adaptive;
-    const T orientation = orient2d(v1.raw(), v2.raw(), p.raw());
+    const T orientation = orient2d(v1.x, v1.y, v2.x, v2.y, p.x, p.y);
     if(orientation < T(0))
         return PtLineLocation::Right;
     if(orientation == T(0))
@@ -283,7 +277,7 @@ bool isInCircumcircle(
     const V2d<T>& v3)
 {
     using namespace predicates::adaptive;
-    return incircle(v1.raw(), v2.raw(), v3.raw(), p.raw()) > T(0);
+    return incircle(v1.x, v1.y, v2.x, v2.y, v3.x, v3.y, p.x, p.y) > T(0);
 }
 
 template <typename T>

--- a/CDT/include/CDTUtils.hpp
+++ b/CDT/include/CDTUtils.hpp
@@ -29,21 +29,31 @@ V2d<T> V2d<T>::make(const T x, const T y)
 //*****************************************************************************
 // Box2d
 //*****************************************************************************
-template <typename T>
-Box2d<T> Box2d<T>::envelop(const std::vector<V2d<T> >& vertices)
+
+template <typename T, typename TVertexIter, typename TGetVertexCoord>
+Box2d<T> envelopBox(
+    TVertexIter first,
+    TVertexIter last,
+    TGetVertexCoord getX,
+    TGetVertexCoord getY)
 {
     const T max = std::numeric_limits<T>::max();
     Box2d<T> box = {{max, max}, {-max, -max}};
-    typedef typename std::vector<V2d<T> >::const_iterator Cit;
-    for(Cit it = vertices.begin(); it != vertices.end(); ++it)
+    for(; first != last; ++first)
     {
-        const V2d<T>& v = *it;
-        box.min.x = std::min(v.x, box.min.x);
-        box.max.x = std::max(v.x, box.max.x);
-        box.min.y = std::min(v.y, box.min.y);
-        box.max.y = std::max(v.y, box.max.y);
+        box.min.x = std::min(getX(*first), box.min.x);
+        box.max.x = std::max(getX(*first), box.max.x);
+        box.min.y = std::min(getY(*first), box.min.y);
+        box.max.y = std::max(getY(*first), box.max.y);
     }
     return box;
+}
+
+template <typename T>
+Box2d<T> envelopBox(const std::vector<V2d<T> >& vertices)
+{
+    return envelopBox<T>(
+        vertices.begin(), vertices.end(), getX_V2d<T>, getY_V2d<T>);
 }
 
 //*****************************************************************************

--- a/CDT/include/predicates.h
+++ b/CDT/include/predicates.h
@@ -40,12 +40,36 @@ namespace  predicates {
 	//@note : these are provided primarily for illustrative purposes and adaptive routines should be preferred
 	namespace exact {
 		//@brief   : determine if the 2d point c is above, on, or below the line defined by a and b
+		//@param ax: X-coordinate of a
+		//@param ay: Y-coordinate of a
+		//@param bx: X-coordinate of b
+		//@param by: Y-coordinate of b
+		//@param cx: X-coordinate of c
+		//@param cy: Y-coordinate of c
+		//@return  : determinant of {{ax - cx, ay - cy}, {bx - cx, by - cy}}
+		//@note    : positive, 0, negative result for c above, on, or below the line defined by a -> b
+		template <typename T> T orient2d(T const ax, T const ay, T const bx, T const by, T const cx, T const cy);
+
+		//@brief   : determine if the 2d point c is above, on, or below the line defined by a and b
 		//@param pa: pointer to a as {x, y}
 		//@param pb: pointer to b as {x, y}
 		//@param pc: pointer to c as {x, y}
 		//@return  : determinant of {{ax - cx, ay - cy}, {bx - cx, by - cy}}
 		//@note    : positive, 0, negative result for c above, on, or below the line defined by a -> b
 		template <typename T> T orient2d(T const*const pa, T const*const pb, T const*const pc);
+
+		//@brief   : determine if the 2d point d is inside, on, or outside the circle defined by a, b, and c
+		//@param ax: X-coordinate of a
+		//@param ay: Y-coordinate of a
+		//@param bx: X-coordinate of b
+		//@param by: Y-coordinate of b
+		//@param cx: X-coordinate of c
+		//@param cy: Y-coordinate of c
+		//@param dx: X-coordinate of d
+		//@param dy: Y-coordinate of d
+		//@return  : determinant of {{ax - dx, ay - dy, (ax - dx)^2 + (ay - dy)^2}, {bx - dx, by - dy, (bx - dx)^2 + (by - dy)^2}, {cx - dx, cy - dy, (cx - dx)^2 + (cy - dy)^2}}
+		//@note    : positive, 0, negative result for d inside, on, or outside the circle defined by a, b, and c
+		template <typename T> T incircle(T const ax, T const ay, T const bx, T const by, T const cx, T const cy, T const dx, T const dy);
 
 		//@brief   : determine if the 2d point d is inside, on, or outside the circle defined by a, b, and c
 		//@param pa: pointer to a as {x, y}
@@ -80,12 +104,36 @@ namespace  predicates {
 	//@note : these should have the same accuracy but are significantly faster when determinants are large
 	namespace adaptive {
 		//@brief   : determine if the 2d point c is above, on, or below the line defined by a and b
+		//@param ax: X-coordinate of a
+		//@param ay: Y-coordinate of a
+		//@param bx: X-coordinate of b
+		//@param by: Y-coordinate of b
+		//@param cx: X-coordinate of c
+		//@param cy: Y-coordinate of c
+		//@return  : determinant of {{ax - cx, ay - cy}, {bx - cx, by - cy}}
+		//@note    : positive, 0, negative result for c above, on, or below the line defined by a -> b
+		template <typename T> T orient2d(T const ax, T const ay, T const bx, T const by, T const cx, T const cy);
+
+		//@brief   : determine if the 2d point c is above, on, or below the line defined by a and b
 		//@param pa: pointer to a as {x, y}
 		//@param pb: pointer to b as {x, y}
 		//@param pc: pointer to c as {x, y}
 		//@return  : determinant of {{ax - cx, ay - cy}, {bx - cx, by - cy}}
 		//@note    : positive, 0, negative result for c above, on, or below the line defined by a -> b
 		template <typename T> T orient2d(T const*const pa, T const*const pb, T const*const pc);
+
+		//@brief   : determine if the 2d point d is inside, on, or outside the circle defined by a, b, and c
+		//@param ax: X-coordinate of a
+		//@param ay: Y-coordinate of a
+		//@param bx: X-coordinate of b
+		//@param by: Y-coordinate of b
+		//@param cx: X-coordinate of c
+		//@param cy: Y-coordinate of c
+		//@param dx: X-coordinate of d
+		//@param dy: Y-coordinate of d
+		//@return  : determinant of {{ax - dx, ay - dy, (ax - dx)^2 + (ay - dy)^2}, {bx - dx, by - dy, (bx - dx)^2 + (by - dy)^2}, {cx - dx, cy - dy, (cx - dx)^2 + (cy - dy)^2}}
+		//@note    : positive, 0, negative result for d inside, on, or outside the circle defined by a, b, and c
+		template <typename T> T incircle(T const ax, T const ay, T const bx, T const by, T const cx, T const cy, T const dx, T const dy);
 
 		//@brief   : determine if the 2d point d is inside, on, or outside the circle defined by a, b, and c
 		//@param pa: pointer to a as {x, y}
@@ -434,47 +482,43 @@ namespace detail {
 }
 
 	namespace exact {
-		//@brief   : determine if the 2d point c is above, on, or below the line defined by a and b
-		//@param pa: pointer to a as {x, y}
-		//@param pb: pointer to b as {x, y}
-		//@param pc: pointer to c as {x, y}
-		//@return  : determinant of {{ax - cx, ay - cy}, {bx - cx, by - cy}}
-		//@note    : positive, 0, negative result for c above, on, or below the line defined by a -> b
-		template <typename T> T orient2d(T const*const pa, T const*const pb, T const*const pc) {
-			const detail::Expansion<T, 4> aterms = detail::ExpansionBase<T>::TwoTwoDiff(pa[0], pb[1], pa[0], pc[1]);
-			const detail::Expansion<T, 4> bterms = detail::ExpansionBase<T>::TwoTwoDiff(pb[0], pc[1], pb[0], pa[1]);
-			const detail::Expansion<T, 4> cterms = detail::ExpansionBase<T>::TwoTwoDiff(pc[0], pa[1], pc[0], pb[1]);
+		template <typename T> T orient2d(T const ax, T const ay, T const bx, T const by, T const cx, T const cy)
+		{
+			const detail::Expansion<T, 4> aterms = detail::ExpansionBase<T>::TwoTwoDiff(ax, by, ax, cy);
+			const detail::Expansion<T, 4> bterms = detail::ExpansionBase<T>::TwoTwoDiff(bx, cy, bx, ay);
+			const detail::Expansion<T, 4> cterms = detail::ExpansionBase<T>::TwoTwoDiff(cx, ay, cx, by);
 			const detail::Expansion<T, 12> w = aterms + bterms + cterms;
 			return w.mostSignificant();
 		}
 
-		//@brief   : determine if the 2d point d is inside, on, or outside the circle defined by a, b, and c
-		//@param pa: pointer to a as {x, y}
-		//@param pb: pointer to b as {x, y}
-		//@param pc: pointer to c as {x, y}
-		//@param pc: pointer to d as {x, y}
-		//@return  : determinant of {{ax - dx, ay - dy, (ax - dx)^2 + (ay - dy)^2}, {bx - dx, by - dy, (bx - dx)^2 + (by - dy)^2}, {cx - dx, cy - dy, (cx - dx)^2 + (cy - dy)^2}}
-		//@note    : positive, 0, negative result for d inside, on, or outside the circle defined by a, b, and c
-		template <typename T> T incircle(T const*const pa, T const*const pb, T const*const pc, T const*const pd) {
-			const detail::Expansion<T, 4> ab = detail::ExpansionBase<T>::TwoTwoDiff(pa[0], pb[1], pb[0], pa[1]);
-			const detail::Expansion<T, 4> bc = detail::ExpansionBase<T>::TwoTwoDiff(pb[0], pc[1], pc[0], pb[1]);
-			const detail::Expansion<T, 4> cd = detail::ExpansionBase<T>::TwoTwoDiff(pc[0], pd[1], pd[0], pc[1]);
-			const detail::Expansion<T, 4> da = detail::ExpansionBase<T>::TwoTwoDiff(pd[0], pa[1], pa[0], pd[1]);
-			const detail::Expansion<T, 4> ac = detail::ExpansionBase<T>::TwoTwoDiff(pa[0], pc[1], pc[0], pa[1]);
-			const detail::Expansion<T, 4> bd = detail::ExpansionBase<T>::TwoTwoDiff(pb[0], pd[1], pd[0], pb[1]);
+		template <typename T> T orient2d(T const*const pa, T const*const pb, T const*const pc) {
+			return orient2d(pa[0], pa[1], pb[0], pb[1], pc[0], pc[1]);
+		}
+
+		template <typename T> T incircle(T const ax, T const ay, T const bx, T const by, T const cx, T const cy, T const dx, T const dy) {
+			const detail::Expansion<T, 4> ab = detail::ExpansionBase<T>::TwoTwoDiff(ax, by, bx, ay);
+			const detail::Expansion<T, 4> bc = detail::ExpansionBase<T>::TwoTwoDiff(bx, cy, cx, by);
+			const detail::Expansion<T, 4> cd = detail::ExpansionBase<T>::TwoTwoDiff(cx, dy, dx, cy);
+			const detail::Expansion<T, 4> da = detail::ExpansionBase<T>::TwoTwoDiff(dx, ay, ax, dy);
+			const detail::Expansion<T, 4> ac = detail::ExpansionBase<T>::TwoTwoDiff(ax, cy, cx, ay);
+			const detail::Expansion<T, 4> bd = detail::ExpansionBase<T>::TwoTwoDiff(bx, dy, dx, by);
 
 			const detail::Expansion<T, 12> abc = ab + bc - ac;
 			const detail::Expansion<T, 12> bcd = bc + cd - bd;
 			const detail::Expansion<T, 12> cda = cd + da + ac;
 			const detail::Expansion<T, 12> dab = da + ab + bd;
 
-			const detail::Expansion<T, 96> adet = bcd * pa[0] *  pa[0] + bcd * pa[1] *  pa[1];
-			const detail::Expansion<T, 96> bdet = cda * pb[0] * -pb[0] + cda * pb[1] * -pb[1];
-			const detail::Expansion<T, 96> cdet = dab * pc[0] *  pc[0] + dab * pc[1] *  pc[1];
-			const detail::Expansion<T, 96> ddet = abc * pd[0] * -pd[0] + abc * pd[1] * -pd[1];
+			const detail::Expansion<T, 96> adet = bcd * ax *  ax + bcd * ay *  ay;
+			const detail::Expansion<T, 96> bdet = cda * bx * -bx + cda * by * -by;
+			const detail::Expansion<T, 96> cdet = dab * cx *  cx + dab * cy *  cy;
+			const detail::Expansion<T, 96> ddet = abc * dx * -dx + abc * dy * -dy;
 
 			const detail::Expansion<T, 384> deter = (adet + bdet) + (cdet + ddet);
 			return deter.mostSignificant();
+		}
+
+		template <typename T> T incircle(T const*const pa, T const*const pb, T const*const pc, T const*const pd) {
+			return incircle(pa[0], pa[1], pb[0], pb[1], pc[0], pc[1], pd[0], pd[1]);
 		}
 
 		//@brief   : determine if the 3d point d is above, on, or below the plane defined by a, b, and c
@@ -592,17 +636,11 @@ namespace detail {
 	template <typename T> const T Constants<T>::isperrboundC   = (T(71) + T(1408) * Epsilon<T>()) * Epsilon<T>() * Epsilon<T>();
 
 	namespace adaptive {
-		//@brief   : determine if the 2d point c is above, on, or below the line defined by a and b
-		//@param pa: pointer to a as {x, y}
-		//@param pb: pointer to b as {x, y}
-		//@param pc: pointer to c as {x, y}
-		//@return  : determinant of {{ax - cx, ay - cy}, {bx - cx, by - cy}}
-		//@note    : positive, 0, negative result for c above, on, or below the line defined by a -> b
-		template <typename T> T orient2d(T const*const pa, T const*const pb, T const*const pc) {
-			const T acx = pa[0] - pc[0];
-			const T bcx = pb[0] - pc[0];
-			const T acy = pa[1] - pc[1];
-			const T bcy = pb[1] - pc[1];
+		template <typename T> T orient2d(T const ax, T const ay, T const bx, T const by, T const cx, T const cy) {
+			const T acx = ax - cx;
+			const T bcx = bx - cx;
+			const T acy = ay - cy;
+			const T bcy = by - cy;
 			const T detleft = acx * bcy;
 			const T detright = acy * bcx;
 			T det = detleft - detright;
@@ -618,10 +656,10 @@ namespace detail {
 			errbound = Constants<T>::ccwerrboundB * detsum;
 			if(std::abs(det) >= std::abs(errbound)) return det;
 
-			const T acxtail = detail::ExpansionBase<T>::MinusTail(pa[0], pc[0], acx);
-			const T bcxtail = detail::ExpansionBase<T>::MinusTail(pb[0], pc[0], bcx);
-			const T acytail = detail::ExpansionBase<T>::MinusTail(pa[1], pc[1], acy);
-			const T bcytail = detail::ExpansionBase<T>::MinusTail(pb[1], pc[1], bcy);
+			const T acxtail = detail::ExpansionBase<T>::MinusTail(ax, cx, acx);
+			const T bcxtail = detail::ExpansionBase<T>::MinusTail(bx, cx, bcx);
+			const T acytail = detail::ExpansionBase<T>::MinusTail(ay, cy, acy);
+			const T bcytail = detail::ExpansionBase<T>::MinusTail(by, cy, bcy);
 			if(T(0) == acxtail && T(0) == bcxtail && T(0) == acytail && T(0) == bcytail) return det;
 
 			errbound = Constants<T>::ccwerrboundC * detsum + Constants<T>::resulterrbound * std::abs(det);
@@ -632,20 +670,17 @@ namespace detail {
 			return D.mostSignificant();
 		}
 
-		//@brief   : determine if the 2d point d is inside, on, or outside the circle defined by a, b, and c
-		//@param pa: pointer to a as {x, y}
-		//@param pb: pointer to b as {x, y}
-		//@param pc: pointer to c as {x, y}
-		//@param pc: pointer to d as {x, y}
-		//@return  : determinant of {{ax - dx, ay - dy, (ax - dx)^2 + (ay - dy)^2}, {bx - dx, by - dy, (bx - dx)^2 + (by - dy)^2}, {cx - dx, cy - dy, (cx - dx)^2 + (cy - dy)^2}}
-		//@note    : positive, 0, negative result for d inside, on, or outside the circle defined by a, b, and c
-		template <typename T> T incircle(T const*const pa, T const*const pb, T const*const pc, T const*const pd) {
-			const T adx = pa[0] - pd[0];
-			const T bdx = pb[0] - pd[0];
-			const T cdx = pc[0] - pd[0];
-			const T ady = pa[1] - pd[1];
-			const T bdy = pb[1] - pd[1];
-			const T cdy = pc[1] - pd[1];
+		template <typename T> T orient2d(T const*const pa, T const*const pb, T const*const pc) {
+			return orient2d(pa[0], pa[1], pb[0], pb[1], pc[0], pc[1]);
+		}
+
+		template <typename T> T incircle(T const ax, T const ay, T const bx, T const by, T const cx, T const cy, T const dx, T const dy) {
+			const T adx = ax - dx;
+			const T bdx = bx - dx;
+			const T cdx = cx - dx;
+			const T ady = ay - dy;
+			const T bdy = by - dy;
+			const T cdy = cy - dy;
 			const T bdxcdy = bdx * cdy;
 			const T cdxbdy = cdx * bdy;
 			const T cdxady = cdx * ady;
@@ -673,12 +708,12 @@ namespace detail {
 			errbound = Constants<T>::iccerrboundB * permanent;
 			if(std::abs(det) >= std::abs(errbound)) return det;
 
-			const T adxtail = detail::ExpansionBase<T>::MinusTail(pa[0], pd[0], adx);
-			const T adytail = detail::ExpansionBase<T>::MinusTail(pa[1], pd[1], ady);
-			const T bdxtail = detail::ExpansionBase<T>::MinusTail(pb[0], pd[0], bdx);
-			const T bdytail = detail::ExpansionBase<T>::MinusTail(pb[1], pd[1], bdy);
-			const T cdxtail = detail::ExpansionBase<T>::MinusTail(pc[0], pd[0], cdx);
-			const T cdytail = detail::ExpansionBase<T>::MinusTail(pc[1], pd[1], cdy);
+			const T adxtail = detail::ExpansionBase<T>::MinusTail(ax, dx, adx);
+			const T adytail = detail::ExpansionBase<T>::MinusTail(ay, dy, ady);
+			const T bdxtail = detail::ExpansionBase<T>::MinusTail(bx, dx, bdx);
+			const T bdytail = detail::ExpansionBase<T>::MinusTail(by, dy, bdy);
+			const T cdxtail = detail::ExpansionBase<T>::MinusTail(cx, dx, cdx);
+			const T cdytail = detail::ExpansionBase<T>::MinusTail(cy, dy, cdy);
 			if(T(0) == adxtail && T(0) == bdxtail && T(0) == cdxtail && T(0) == adytail && T(0) == bdytail && T(0) == cdytail) return det;
 
 			errbound = Constants<T>::iccerrboundC * permanent + Constants<T>::resulterrbound * std::abs(det);
@@ -689,7 +724,11 @@ namespace detail {
 			    +  ((cdx * cdx + cdy * cdy) * ((adx * bdytail + bdy * adxtail) - (ady * bdxtail + bdx * adytail))
 			    +   (adx * bdy - ady * bdx) *  (cdx * cdxtail + cdy * cdytail) * T(2));
 			if(std::abs(det) >= std::abs(errbound)) return det;
-			return exact::incircle(pa, pb, pc, pd);
+			return exact::incircle(ax, ay, bx, by, cx, cy, dx, dy);
+		}
+
+		template <typename T> T incircle(T const*const pa, T const*const pb, T const*const pc, T const*const pd) {
+			return incircle(pa[0], pa[1], pb[0], pb[1], pc[0], pc[1], pd[0], pd[1]);
 		}
 
 		//@brief   : determine if the 3d point d is above, on, or below the plane defined by a, b, and c

--- a/visualizer/main.cpp
+++ b/visualizer/main.cpp
@@ -125,7 +125,7 @@ public slots:
         fout << m_cdt.vertices.size() << ' ' << m_cdt.triangles.size()
              << " 0\n";
         // Write vertices
-        const Box2d box = Box2d::envelop(m_points);
+        const Box2d box = envelopBox(m_points);
         const CoordType stZ =
             -std::fmax(box.max.x - box.min.x, box.max.y - box.min.y);
         std::size_t counter = 0;
@@ -251,7 +251,7 @@ private:
     }
     void initTransform()
     {
-        m_sceneBox = Box2d::envelop(m_points);
+        m_sceneBox = envelopBox(m_points);
         QPointF sceneCenter(
             (m_sceneBox.min.x + m_sceneBox.max.x) / CoordType(2),
             (m_sceneBox.min.y + m_sceneBox.max.y) / CoordType(2));


### PR DESCRIPTION
#21 Support cutom point types in API:

Takes points as iterator range and X-/Y-getters as function objects to enable seamless addition and duplicate removal of custom point types.
