### PR TITLE
Feature/19 initialize with grid

### DIFF
--- a/CDT/CMakeLists.txt
+++ b/CDT/CMakeLists.txt
@@ -66,6 +66,8 @@ if(CDT_USE_AS_COMPILED_LIBRARY)
         include/CDT.hpp
         include/CDTUtils.hpp
         include/predicates.h
+        extras/VerifyTopology.h
+        extras/InitializeWithGrid.h
     )
     add_library(${PROJECT_NAME} ${cdt_sources} ${cdt_headers})
     # Set symbols visibility to hidden by default

--- a/CDT/CMakeLists.txt
+++ b/CDT/CMakeLists.txt
@@ -159,6 +159,7 @@ if(DOXYGEN_FOUND)
     message(STATUS "Doxygen found: adding documentation target.")
     set(DOXYGEN_EXCLUDE_PATTERNS
         */predicates.h
+        conanfile.py
     )
     # doxygen settings can be set here, prefixed with "DOXYGEN_"
     set(DOXYGEN_SOURCE_BROWSER YES)

--- a/CDT/extras/InitializeWithGrid.h
+++ b/CDT/extras/InitializeWithGrid.h
@@ -1,0 +1,168 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * @file
+ * Helper function to initialize triangulation with regular grid instead of
+ * super-triangle
+ */
+
+#ifndef CDT_HmXGv083vZCrT3OXASD9
+#define CDT_HmXGv083vZCrT3OXASD9
+
+#include "CDT.h"
+#include "CDTUtils.h"
+
+#include <cstddef>
+#include <iterator>
+
+namespace CDT
+{
+namespace detail
+{
+
+/**
+ * Generate grid vertices
+ *
+ * @tparam T type of vertex coordinates (e.g., float, double)
+ * @tparam OutputIt output iterator
+ * @param outFirst the beginning of the destination range
+ * @param xmin minimum X-coordinate of grid
+ * @param xmax maximum X-coordinate of grid
+ * @param ymin minimum Y-coordinate of grid
+ * @param ymax maximum Y-coordinate of grid
+ * @param xres grid X-resolution
+ * @param yres grid Y-resolution
+ */
+template <typename T, typename OutputIt>
+void generateGridVertices(
+    OutputIt outFirst,
+    const T xmin,
+    const T xmax,
+    const T ymin,
+    const T ymax,
+    const std::size_t xres,
+    const std::size_t yres)
+{
+    const T xstep = (xmax - xmin) / xres;
+    const T ystep = (ymax - ymin) / yres;
+    T y = ymin;
+    for(std::size_t iy = 0; iy <= yres; ++iy, y += ystep)
+    {
+        T x = xmin;
+        for(std::size_t ix = 0; ix <= xres; ++ix, x += xstep)
+        {
+            Vertex<T> v;
+            v.pos = V2d<T>::make(x, y);
+
+            const std::size_t i = iy * xres + ix;
+            // left-up
+            if(ix > 0 && iy < yres)
+            {
+                v.triangles.push_back(2 * (i - 1));
+                v.triangles.push_back(2 * (i - 1) + 1);
+            }
+            // right-up
+            if(ix < xres && iy < yres)
+            {
+                v.triangles.push_back(2 * i);
+            }
+            // left-down
+            if(ix > 0 && iy > 0)
+            {
+                v.triangles.push_back(2 * (i - xres - 1) + 1);
+            }
+            // right-down
+            if(ix < xres && iy > 0)
+            {
+                v.triangles.push_back(2 * (i - xres));
+                v.triangles.push_back(2 * (i - xres) + 1);
+            }
+            *outFirst++ = v;
+        }
+    }
+}
+
+/**
+ * Generate grid triangles
+ *
+ * @tparam OutputIt output iterator
+ * @param outFirst the beginning of the destination range
+ * @param xres grid X-resolution
+ * @param yres grid Y-resolution
+ */
+template <typename OutputIt>
+void generateGridTriangles(
+    OutputIt outFirst,
+    const std::size_t xres,
+    const std::size_t yres)
+{
+    for(std::size_t iy = 0; iy < yres; ++iy)
+    {
+        for(std::size_t ix = 0; ix < xres; ++ix)
+        {
+            // 2___3           v3
+            // |\  |           /\
+            // | \ |        n3/  \n2
+            // |__\|         /____\
+            // 0   1       v1  n1  v2
+            const std::size_t i = iy * xres + ix;
+            const std::size_t iv = iy * (xres + 1) + ix;
+            const VertInd vv[4] = {iv, iv + 1, iv + xres + 1, iv + xres + 2};
+            Triangle t;
+
+            t.vertices = {vv[0], vv[1], vv[2]};
+            t.neighbors = {
+                iy ? 2 * i - xres * 2 + 1 : noNeighbor,
+                2 * i + 1,
+                ix ? 2 * i - 1 : noNeighbor};
+            *outFirst++ = t;
+
+            t.vertices = {vv[1], vv[3], vv[2]};
+            t.neighbors = {
+                ix < xres - 1 ? 2 * i + 2 : noNeighbor,
+                iy < yres - 1 ? 2 * i + xres * 2 : noNeighbor,
+                2 * i};
+            *outFirst++ = t;
+        }
+    }
+}
+
+} // namespace detail
+
+/**
+ * Make a triangulation that uses regular grid triangles instead of
+ * super-triangle
+ *
+ * @tparam T type of vertex coordinates (e.g., float, double)
+ * @param xmin minimum X-coordinate of grid
+ * @param xmax maximum X-coordinate of grid
+ * @param ymin minimum Y-coordinate of grid
+ * @param ymax maximum Y-coordinate of grid
+ * @param xres grid X-resolution
+ * @param yres grid Y-resolution
+ * @param out triangulation to initialize with grid super-geometry
+ */
+template <typename T>
+void initializeWithGrid(
+    const T xmin,
+    const T xmax,
+    const T ymin,
+    const T ymax,
+    const std::size_t xres,
+    const std::size_t yres,
+    Triangulation<T>& out)
+{
+    out.triangles.reserve(xres * yres * 2);
+    out.vertices.reserve((xres + 1) * (yres + 1));
+    detail::generateGridVertices(
+        std::back_inserter(out.vertices), xmin, xmax, ymin, ymax, xres, yres);
+    detail::generateGridTriangles(
+        std::back_inserter(out.triangles), xres, yres);
+    out.initializedWithCustomSuperGeometry();
+}
+
+} // namespace CDT
+
+#endif

--- a/CDT/include/CDT.h
+++ b/CDT/include/CDT.h
@@ -45,6 +45,21 @@ struct CDT_EXPORT FindingClosestPoint
     };
 };
 
+/// Enum of what type of geometry used to embed triangulation into
+struct CDT_EXPORT SuperGeometryType
+{
+    /**
+     * The Enum itself
+     * @note needed to pre c++11 compilers that don't support 'class enum'
+     */
+    enum Enum
+    {
+        SuperTriangle, ///< conventional super-triangle
+        Custom, ///< user-specified custom geometry (e.g., grid)
+    };
+};
+
+
 /// Constant representing no valid neighbor for a triangle
 const static TriInd noNeighbor(std::numeric_limits<std::size_t>::max());
 /// Constant representing no valid vertex for a triangle
@@ -126,6 +141,11 @@ public:
      * @note detecting holes relies on layer peeling based on layer depth
      */
     void eraseOuterTrianglesAndHoles();
+    /**
+     * Call this method after directly setting custom super-geometry via
+     * vertices and triangles members
+     */
+    void initializedWithCustomSuperGeometry();
 
 private:
     /*____ Detail __*/
@@ -192,6 +212,8 @@ private:
 #endif
     std::size_t m_nRandSamples;
     FindingClosestPoint::Enum m_closestPtMode;
+    std::size_t m_nTargetVerts;
+    SuperGeometryType::Enum m_superGeomType;
 };
 
 /**
@@ -412,8 +434,9 @@ void Triangulation<T>::insertEdges(
     for(; first != last; ++first)
     {
         // +3 to account for super-triangle vertices
-        insertEdge(
-            Edge(VertInd(getStart(*first) + 3), VertInd(getEnd(*first) + 3)));
+        insertEdge(Edge(
+            VertInd(getStart(*first) + m_nTargetVerts),
+            VertInd(getEnd(*first) + m_nTargetVerts)));
     }
     eraseDummies();
 }

--- a/visualizer/main.cpp
+++ b/visualizer/main.cpp
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 #include "CDT.h"
 #include "VerifyTopology.h"
+#include "InitializeWithGrid.h"
 
 #include <fstream>
 #include <iostream>
@@ -192,6 +193,15 @@ private:
                     ? std::vector<V2d>(&m_points[0], &m_points[m_ptLimit])
                     : m_points;
             const CDT::DuplicatesInfo duplInfo = CDT::RemoveDuplicates(pts);
+
+            Box2d bbox = envelopBox(pts);
+            bbox.min.x -= 0.1;
+            bbox.min.y -= 0.1;
+            bbox.max.x += 0.1;
+            bbox.max.y += 0.1;
+            CDT::initializeWithGrid(
+                bbox.min.x, bbox.max.x, bbox.min.y, bbox.max.y, 3, 3, m_cdt);
+
             m_cdt.insertVertices(pts);
             if(m_ptLimit >= m_points.size() && !m_edges.empty())
             {

--- a/visualizer/main.cpp
+++ b/visualizer/main.cpp
@@ -3,7 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 #include "CDT.h"
 #include "VerifyTopology.h"
-#include "InitializeWithGrid.h"
 
 #include <fstream>
 #include <iostream>
@@ -193,14 +192,6 @@ private:
                     ? std::vector<V2d>(&m_points[0], &m_points[m_ptLimit])
                     : m_points;
             const CDT::DuplicatesInfo duplInfo = CDT::RemoveDuplicates(pts);
-
-            Box2d bbox = envelopBox(pts);
-            bbox.min.x -= 0.1;
-            bbox.min.y -= 0.1;
-            bbox.max.x += 0.1;
-            bbox.max.y += 0.1;
-            CDT::initializeWithRegularGrid(
-                bbox.min.x, bbox.max.x, bbox.min.y, bbox.max.y, 3, 3, m_cdt);
 
             m_cdt.insertVertices(pts);
             if(m_ptLimit >= m_points.size() && !m_edges.empty())

--- a/visualizer/main.cpp
+++ b/visualizer/main.cpp
@@ -199,7 +199,7 @@ private:
             bbox.min.y -= 0.1;
             bbox.max.x += 0.1;
             bbox.max.y += 0.1;
-            CDT::initializeWithGrid(
+            CDT::initializeWithRegularGrid(
                 bbox.min.x, bbox.max.x, bbox.min.y, bbox.max.y, 3, 3, m_cdt);
 
             m_cdt.insertVertices(pts);


### PR DESCRIPTION
Implement functionality to use any custom geometry as a target instead of a super-triangle.
`InitializeWithGrid.h` contains functions to initialize triangulation with regular or irregular grids:

```c++
/**
 * Make a triangulation that uses regular grid triangles instead of
 * super-triangle
 *
 * @tparam T type of vertex coordinates (e.g., float, double)
 * @param xmin minimum X-coordinate of grid
 * @param xmax maximum X-coordinate of grid
 * @param ymin minimum Y-coordinate of grid
 * @param ymax maximum Y-coordinate of grid
 * @param xres grid X-resolution
 * @param yres grid Y-resolution
 * @param out triangulation to initialize with grid super-geometry
 */
template <typename T>
void initializeWithRegularGrid(
    const T xmin,
    const T xmax,
    const T ymin,
    const T ymax,
    const std::size_t xres,
    const std::size_t yres,
    Triangulation<T>& out)

/**
 * Make a triangulation that uses irregular grid triangles instead of
 * super-triangle. Irregular grid is given by collections of X- and Y-ticks
 *
 * @tparam T type of vertex coordinates (e.g., float, double)
 * @tparam TXCoordIter iterator dereferencing to X coordinate
 * @tparam TYCoordIter iterator dereferencing to Y coordinate
 * @param xfirst beginning of X-ticks range
 * @param xlast end of X-ticks range
 * @param yfirst beginning of Y-ticks range
 * @param ylast end of Y-ticks range
 * @param out triangulation to initialize with grid super-geometry
 */
template <typename T, typename TXCoordIter, typename TYCoordIter>
void initializeWithIrregularGrid(
    const TXCoordIter xfirst,
    const TXCoordIter xlast,
    const TYCoordIter yfirst,
    const TYCoordIter ylast,
    Triangulation<T>& out)
```