### PR TITLE
#34 Do not allow flipping a fixed edge

### DIFF
--- a/CDT/include/CDT.hpp
+++ b/CDT/include/CDT.hpp
@@ -453,6 +453,10 @@ bool Triangulation<T>::isFlipNeeded(
     const VertInd iVopo = tOpo.vertices[i];
     const VertInd iVcw = tOpo.vertices[cw(i)];
     const VertInd iVccw = tOpo.vertices[ccw(i)];
+
+    if(fixedEdges.count(Edge(iVcw, iVccw)))
+        return false; // flip not needed if the original edge is fixed
+
     const V2d<T>& v1 = vertices[iVcw].pos;
     const V2d<T>& v2 = vertices[iVopo].pos;
     const V2d<T>& v3 = vertices[iVccw].pos;


### PR DESCRIPTION
When vertices are inserted into a triangulation that already
has some constraints (fixed edges): fixed edges should not be flipped.