### PR TITLE
Kdtree locator customization points

### DIFF
--- a/CDT/extras/InitializeWithGrid.h
+++ b/CDT/extras/InitializeWithGrid.h
@@ -190,7 +190,11 @@ void initializeWithRegularGrid(
  * @param ylast end of Y-ticks range
  * @param out triangulation to initialize with grid super-geometry
  */
-template <typename T, typename TNearPointLocator, typename TXCoordIter, typename TYCoordIter>
+template <
+    typename T,
+    typename TNearPointLocator,
+    typename TXCoordIter,
+    typename TYCoordIter>
 void initializeWithIrregularGrid(
     const TXCoordIter xfirst,
     const TXCoordIter xlast,

--- a/CDT/include/LocatorKDTree.h
+++ b/CDT/include/LocatorKDTree.h
@@ -31,14 +31,20 @@ public:
         m_kdTree.insert(i, points);
     }
     /// Find nearest point using R-tree
-    VertInd
-    nearPoint(const V2d<TCoordType>& pos, const std::vector<V2d<TCoordType> >& points) const
+    VertInd nearPoint(
+        const V2d<TCoordType>& pos,
+        const std::vector<V2d<TCoordType> >& points) const
     {
         return m_kdTree.nearest(pos, points).second;
     }
 
 private:
-    KDTree::KDTree<TCoordType, NumVerticesInLeaf, InitialStackDepth, StackDepthIncrement> m_kdTree;
+    KDTree::KDTree<
+        TCoordType,
+        NumVerticesInLeaf,
+        InitialStackDepth,
+        StackDepthIncrement>
+        m_kdTree;
 };
 
 } // namespace CDT


### PR DESCRIPTION
The k-d tree point locator was missing template arguments to be passed to the k-d tree instance. It makes more sense to have them in the locator if you want support for multiple locators with a different instantiation of the k-d tree.