### PR TITLE
Replace use of std::random_shuffle with std::shuffle

### DIFF
--- a/CDT/include/CDT.h
+++ b/CDT/include/CDT.h
@@ -520,8 +520,7 @@ namespace CDT
 #ifdef CDT_CXX11_IS_SUPPORTED
 inline void shuffle_indices(std::vector<VertInd>& indices)
 {
-    std::random_device rd;
-    std::mt19937 g(rd());
+    std::mt19937 g(9001);
     std::shuffle(indices.begin(), indices.end(), g);
 }
 #else

--- a/CDT/include/CDT.h
+++ b/CDT/include/CDT.h
@@ -517,11 +517,25 @@ struct hash<CDT::V2d<T> >
 namespace CDT
 {
 
+#ifdef CDT_CXX11_IS_SUPPORTED
+inline void shuffle_indices(std::vector<VertInd>& indices)
+{
+    std::random_device rd;
+    std::mt19937 g(rd());
+    std::shuffle(indices.begin(), indices.end(), g);
+}
+#else
 inline size_t randomCDT(const size_t i)
 {
     static mt19937 g(9001);
     return g() % i;
 }
+
+inline void shuffle_indices(std::vector<VertInd>& indices)
+{
+    std::random_shuffle(indices.begin(), indices.end(), randomCDT);
+}
+#endif
 
 //-----------------------
 // Triangulation methods
@@ -560,7 +574,7 @@ void Triangulation<T, TNearPointLocator>::insertVertices(
         VertInd value = nExistingVerts;
         for(Iter it = ii.begin(); it != ii.end(); ++it, ++value)
             *it = value;
-        std::random_shuffle(ii.begin(), ii.end(), randomCDT);
+        shuffle_indices(ii);
         for(Iter it = ii.begin(); it != ii.end(); ++it)
             insertVertex(*it);
         break;

--- a/CDT/include/CDT.h
+++ b/CDT/include/CDT.h
@@ -520,7 +520,7 @@ namespace CDT
 #ifdef CDT_CXX11_IS_SUPPORTED
 inline void shuffle_indices(std::vector<VertInd>& indices)
 {
-    std::mt19937 g(9001);
+    static mt19937 g(9001);
     std::shuffle(indices.begin(), indices.end(), g);
 }
 #else


### PR DESCRIPTION
Replace use of std::random_shuffle with std::shuffle as random_shuffle is removed in C++17.
random_shuffle is kept for pre-C++11.