### PR TITLE
fix cdt_export.h location on install

### DIFF
--- a/.github/workflows/ci_builds.yml
+++ b/.github/workflows/ci_builds.yml
@@ -1,6 +1,6 @@
 name: CI Builds
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   ci_workflow_test:

--- a/CDT/CMakeLists.txt
+++ b/CDT/CMakeLists.txt
@@ -152,7 +152,7 @@ install(
 
 install(
   FILES
-      $<$<BOOL:${CDT_USE_AS_COMPILED_LIBRARY}>:${CMAKE_BINARY_DIR}/cdt_export.h>
+      $<$<BOOL:${CDT_USE_AS_COMPILED_LIBRARY}>:${CMAKE_CURRENT_BINARY_DIR}/cdt_export.h>
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 


### PR DESCRIPTION
If CDT is included as a cmake subdirectory, the location of cdt_export.h is the current binary dir.