### PR TITLE
Fix/export definitions

### DIFF
--- a/CDT/include/CDT.h
+++ b/CDT/include/CDT.h
@@ -301,7 +301,7 @@ template <
     typename TVertexIter,
     typename TGetVertexCoordX,
     typename TGetVertexCoordY>
-CDT_EXPORT DuplicatesInfo FindDuplicates(
+DuplicatesInfo FindDuplicates(
     TVertexIter first,
     TVertexIter last,
     TGetVertexCoordX getX,
@@ -315,7 +315,7 @@ CDT_EXPORT DuplicatesInfo FindDuplicates(
  * @param duplicates information about duplicates
  */
 template <typename TVertex, typename TAllocator>
-CDT_EXPORT void RemoveDuplicates(
+void RemoveDuplicates(
     std::vector<TVertex, TAllocator>& vertices,
     const std::vector<std::size_t>& duplicates);
 
@@ -362,7 +362,7 @@ template <
     typename TGetVertexCoordY,
     typename TVertexAllocator,
     typename TEdgeAllocator>
-CDT_EXPORT DuplicatesInfo RemoveDuplicatesAndRemapEdges(
+DuplicatesInfo RemoveDuplicatesAndRemapEdges(
     std::vector<TVertex, TVertexAllocator>& vertices,
     std::vector<Edge, TEdgeAllocator>& edges,
     TGetVertexCoordX getX,

--- a/CDT/include/CDTUtils.h
+++ b/CDT/include/CDTUtils.h
@@ -118,7 +118,7 @@ const T& getY_V2d(const V2d<T>& v)
 
 /// If two 2D vectors are exactly equal
 template <typename T>
-CDT_EXPORT bool operator==(const CDT::V2d<T>& lhs, const CDT::V2d<T>& rhs)
+bool operator==(const CDT::V2d<T>& lhs, const CDT::V2d<T>& rhs)
 {
     return lhs.x == rhs.x && lhs.y == rhs.y;
 }
@@ -163,7 +163,7 @@ template <
     typename TVertexIter,
     typename TGetVertexCoordX,
     typename TGetVertexCoordY>
-CDT_EXPORT Box2d<T> envelopBox(
+Box2d<T> envelopBox(
     TVertexIter first,
     TVertexIter last,
     TGetVertexCoordX getX,

--- a/CDT/include/CDTUtils.h
+++ b/CDT/include/CDTUtils.h
@@ -306,37 +306,37 @@ CDT_EXPORT PtTriLocation::Enum locatePointTriangle(
     const V2d<T>& v3);
 
 /// Opposed neighbor index from vertex index
-CDT_EXPORT inline Index opoNbr(const Index vertIndex);
+CDT_EXPORT CDT_INLINE_IF_HEADER_ONLY Index opoNbr(const Index vertIndex);
 
 /// Opposed vertex index from neighbor index
-CDT_EXPORT inline Index opoVrt(const Index neighborIndex);
+CDT_EXPORT CDT_INLINE_IF_HEADER_ONLY Index opoVrt(const Index neighborIndex);
 
 /// Index of triangle's neighbor opposed to a vertex
-CDT_EXPORT inline Index
+CDT_EXPORT CDT_INLINE_IF_HEADER_ONLY Index
 opposedTriangleInd(const Triangle& tri, const VertInd iVert);
 
 /// Index of triangle's neighbor opposed to an edge
-CDT_EXPORT inline Index opposedTriangleInd(
+CDT_INLINE_IF_HEADER_ONLY Index opposedTriangleInd(
     const Triangle& tri,
     const VertInd iVedge1,
     const VertInd iVedge2);
 
 /// Index of triangle's vertex opposed to a triangle
-CDT_EXPORT inline Index
+CDT_EXPORT CDT_INLINE_IF_HEADER_ONLY Index
 opposedVertexInd(const Triangle& tri, const TriInd iTopo);
 
 /// If triangle has a given neighbor return neighbor-index, throw otherwise
-CDT_EXPORT inline Index neighborInd(const Triangle& tri, const TriInd iTnbr);
+CDT_EXPORT CDT_INLINE_IF_HEADER_ONLY Index neighborInd(const Triangle& tri, const TriInd iTnbr);
 
 /// If triangle has a given vertex return vertex-index, throw otherwise
-CDT_EXPORT inline Index vertexInd(const Triangle& tri, const VertInd iV);
+CDT_EXPORT CDT_INLINE_IF_HEADER_ONLY Index vertexInd(const Triangle& tri, const VertInd iV);
 
 /// Given triangle and a vertex find opposed triangle
-CDT_EXPORT inline TriInd
+CDT_EXPORT CDT_INLINE_IF_HEADER_ONLY TriInd
 opposedTriangle(const Triangle& tri, const VertInd iVert);
 
 /// Given two triangles, return vertex of first triangle opposed to the second
-CDT_EXPORT inline VertInd
+CDT_EXPORT CDT_INLINE_IF_HEADER_ONLY VertInd
 opposedVertex(const Triangle& tri, const TriInd iTopo);
 
 /// Test if point lies in a circumscribed circle of a triangle
@@ -348,7 +348,7 @@ CDT_EXPORT bool isInCircumcircle(
     const V2d<T>& v3);
 
 /// Test if two vertices share at least one common triangle
-CDT_EXPORT inline bool
+CDT_EXPORT CDT_INLINE_IF_HEADER_ONLY bool
 verticesShareEdge(const TriIndVec& aTris, const TriIndVec& bTris);
 
 /// Distance between two 2D points


### PR DESCRIPTION
I am not completely sure about these changes, but they work in your visualizer build (header_only and compiled) and our build.
dll_import plus inline is a warning (attribute) on gcc (windows with mingw), which is considered an error in our build.