### PR TITLE
#84 improve erase xxx perf

### DIFF
--- a/CDT/extras/VerifyTopology.h
+++ b/CDT/extras/VerifyTopology.h
@@ -32,9 +32,13 @@ template <typename T, typename TNearPointLocator = LocatorKDTree<T> >
 inline bool verifyTopology(const CDT::Triangulation<T, TNearPointLocator>& cdt)
 {
     // Check if vertices' adjacent triangles contain vertex
+    const VerticesTriangles vertTris =
+        cdt.isFinalized()
+            ? calculateTrianglesByVertex(cdt.triangles, cdt.vertices.size())
+            : cdt.vertTris;
     for(VertInd iV(0); iV < VertInd(cdt.vertices.size()); ++iV)
     {
-        const TriIndVec& vTris = cdt.vertTris[iV];
+        const TriIndVec& vTris = vertTris[iV];
         typedef TriIndVec::const_iterator TriIndCit;
         for(TriIndCit it = vTris.begin(); it != vTris.end(); ++it)
         {
@@ -64,7 +68,7 @@ inline bool verifyTopology(const CDT::Triangulation<T, TNearPointLocator>& cdt)
         typedef VerticesArr3::const_iterator VCit;
         for(VCit it = t.vertices.begin(); it != t.vertices.end(); ++it)
         {
-            const TriIndVec& tt = cdt.vertTris[*it];
+            const TriIndVec& tt = vertTris[*it];
             if(std::find(tt.begin(), tt.end(), iT) == tt.end())
                 return false;
         }

--- a/CDT/include/CDT.h
+++ b/CDT/include/CDT.h
@@ -105,7 +105,7 @@ public:
     typedef std::vector<TriIndVec> VerticesTriangles; ///< Triangles by vertex
     V2dVec vertices;            ///< triangulation's vertices
     TriangleVec triangles;      ///< triangulation's triangles
-    EdgeUSet fixedEdges;        ///<  triangulation's constraints (fixed edges)
+    EdgeUSet fixedEdges;        ///< triangulation's constraints (fixed edges)
     VerticesTriangles vertTris; ///< triangles adjacent to each vertex
 
     /** Stores count of overlapping boundaries for a fixed edge. If no entry is
@@ -399,9 +399,12 @@ private:
     TriInd pseudopolyOuterTriangle(const VertInd ia, const VertInd ib) const;
     TriInd addTriangle(const Triangle& t); // note: invalidates iterators!
     TriInd addTriangle(); // note: invalidates triangle iterators!
-    void eraseSuperTriangleVertices(); // no effect if custom geometry is used
-    template <typename TriIndexIter>
-    void eraseTrianglesAtIndices(TriIndexIter first, TriIndexIter last);
+    /**
+     * Remove super-triangle (if used) and triangles with specified indices.
+     * Adjust internal triangulation state accordingly.
+     * @removedTriangles indices of triangles to remove
+     */
+    void finalizeTriangulation(const TriIndUSet& removedTriangles);
     TriIndUSet growToBoundary(std::stack<TriInd> seeds) const;
     void fixEdge(const Edge& edge, const BoundaryOverlapCount overlaps);
     void fixEdge(const Edge& edge);

--- a/CDT/include/CDT.hpp
+++ b/CDT/include/CDT.hpp
@@ -251,7 +251,7 @@ void Triangulation<T, TNearPointLocator>::finalizeTriangulation(
     triangles.erase(triangles.end() - removedTriangles.size(), triangles.end());
     // adjust triangles
     // vertices' adjacent triangles will be re-calculated
-    vertTris = VerticesTriangles(vertices.size());
+    vertTris = VerticesTriangles();
     for(TriInd iT = 0; iT < triangles.size(); ++iT)
     {
         Triangle& t = triangles[iT];
@@ -270,13 +270,11 @@ void Triangulation<T, TNearPointLocator>::finalizeTriangulation(
         }
         if(m_superGeomType == SuperGeometryType::SuperTriangle)
         {
+            // account for removed super-triangle
             VerticesArr3& vv = t.vertices;
             for(VerticesArr3::iterator v = vv.begin(); v != vv.end(); ++v)
             {
-                // account for removed super-triangle
                 *v -= 3;
-                // re-calculate vertices' adjacent triangles
-                vertTris[*v].push_back(iT);
             }
         }
     }
@@ -1471,6 +1469,28 @@ void Triangulation<T, TNearPointLocator>::insertVertices(
 {
     return insertVertices(
         newVertices.begin(), newVertices.end(), getX_V2d<T>, getY_V2d<T>);
+}
+
+template <typename T, typename TNearPointLocator>
+bool Triangulation<T, TNearPointLocator>::isFinalized() const
+{
+    return !vertices.empty() && vertTris.empty();
+}
+
+CDT_INLINE_IF_HEADER_ONLY VerticesTriangles calculateTrianglesByVertex(
+    const TriangleVec& triangles,
+    const VertInd verticesSize)
+{
+    VerticesTriangles vertTris(verticesSize);
+    for(TriInd iT = 0; iT < triangles.size(); ++iT)
+    {
+        const VerticesArr3& vv = triangles[iT].vertices;
+        for(VerticesArr3::const_iterator v = vv.begin(); v != vv.end(); ++v)
+        {
+            vertTris[*v].push_back(iT);
+        }
+    }
+    return vertTris;
 }
 
 template <typename T>


### PR DESCRIPTION
Re-written the way triangulation is finalized and triangles are removed.
This significantly speeds-up the `eraseXXX` methods for some extreme cases.

Triangles by vertex will not be re-calculated when doing calling `erase...` methods.
If necessary triangles by vertex can be calculated using the new helper function `calculateTrianglesByVertex`.