### PR TITLE
Introduce "inner" (non-boundary) constrained edges

### DIFF
--- a/CDT/include/CDTUtils.h
+++ b/CDT/include/CDTUtils.h
@@ -208,7 +208,7 @@ CDT_EXPORT Box2d<T> envelopBox(const std::vector<V2d<T> >& vertices);
 struct CDT_EXPORT Edge
 {
     /// Constructor
-    Edge(VertInd iV1, VertInd iV2);
+    Edge(VertInd iV1, VertInd iV2, bool isBoundaryEdge);
     /// Equals operator
     bool operator==(const Edge& other) const;
     /// Not-equals operator
@@ -219,9 +219,12 @@ struct CDT_EXPORT Edge
     VertInd v2() const;
     /// Edges' vertices
     const std::pair<VertInd, VertInd>& verts() const;
+    /// Whether edge is a boundary edge or just an inner edge
+    bool isBoundary() const;
 
 private:
     std::pair<VertInd, VertInd> m_vertices;
+    bool m_isBoundary;
 };
 
 /// Get edge first vertex
@@ -237,9 +240,15 @@ inline VertInd edge_get_v2(const Edge& e)
 }
 
 /// Get edge second vertex
-inline Edge edge_make(VertInd iV1, VertInd iV2)
+inline Edge edge_make(VertInd iV1, VertInd iV2, bool isBoundaryEdge)
 {
-    return Edge(iV1, iV2);
+    return Edge(iV1, iV2, isBoundaryEdge);
+}
+
+// Get isBoundary property of edge
+inline bool edge_is_boundary(const Edge& e)
+{
+    return e.isBoundary();
 }
 
 typedef std::vector<Edge> EdgeVec;                ///< Vector of edges

--- a/CDT/include/CDTUtils.hpp
+++ b/CDT/include/CDTUtils.hpp
@@ -39,14 +39,16 @@ Box2d<T> envelopBox(const std::vector<V2d<T> >& vertices)
 //*****************************************************************************
 // Edge
 //*****************************************************************************
-CDT_INLINE_IF_HEADER_ONLY Edge::Edge(VertInd iV1, VertInd iV2)
+CDT_INLINE_IF_HEADER_ONLY
+Edge::Edge(VertInd iV1, VertInd iV2, bool isBoundaryEdge = true)
     : m_vertices(
           iV1 < iV2 ? std::make_pair(iV1, iV2) : std::make_pair(iV2, iV1))
+    , m_isBoundary(isBoundaryEdge)
 {}
 
 CDT_INLINE_IF_HEADER_ONLY bool Edge::operator==(const Edge& other) const
 {
-    return m_vertices == other.m_vertices;
+    return m_vertices == other.m_vertices && m_isBoundary == other.m_isBoundary;
 }
 
 CDT_INLINE_IF_HEADER_ONLY bool Edge::operator!=(const Edge& other) const
@@ -67,6 +69,11 @@ CDT_INLINE_IF_HEADER_ONLY VertInd Edge::v2() const
 CDT_INLINE_IF_HEADER_ONLY const std::pair<VertInd, VertInd>& Edge::verts() const
 {
     return m_vertices;
+}
+
+CDT_INLINE_IF_HEADER_ONLY bool Edge::isBoundary() const
+{
+    return m_isBoundary;
 }
 
 //*****************************************************************************


### PR DESCRIPTION
This PR introduces a flag on constraint edges that allows the distinction between "outer" and "inner" constraint edges, that is, edges that will be boundaries when removing the super triangle and holes, and edges that will simply be guaranteed to be part of the triangulation, but do not describe the boundaries of the triangulation, and will be ignored during "hole-detection".

I did not find any other way to achieve this, but maybe there's a much simpler way?

In any case, I wanted to publish our changes, and share them in this way. If you want to merge this, I'll gladly work in any comments that you might have.