### PR TITLE
Update how boost is used for c++98

### DIFF
--- a/CDT/CMakeLists.txt
+++ b/CDT/CMakeLists.txt
@@ -15,13 +15,7 @@ project(
 # export all symbols as we do it by instantiating templates anyway
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
-
 # options
-option(CDT_USE_BOOST
-    "If enabled Boost is used as a fall-back for features missing in C++98
-    and performance tweaks (e.g., using boost::flat_set)"
-    OFF)
-
 option(CDT_USE_AS_COMPILED_LIBRARY
     "If enabled templates for float and double will be instantiated and compiled into a library")
 
@@ -63,16 +57,15 @@ else()
     set(CDT_USE_BOOST ON)
 endif()
 
-message(STATUS "CDT_USE_BOOST is ${CDT_USE_BOOST}")
+if(CDT_USE_STRONG_TYPING)
+    set(CDT_USE_BOOST ON)
+endif()
+
 message(STATUS "CDT_USE_AS_COMPILED_LIBRARY is ${CDT_USE_AS_COMPILED_LIBRARY}")
 message(STATUS "CDT_USE_64_BIT_INDEX_TYPE is ${CDT_USE_64_BIT_INDEX_TYPE}")
 message(STATUS "CDT_ENABLE_TESTING is ${CDT_ENABLE_TESTING}")
 message(STATUS "CDT_USE_STRONG_TYPING is ${CDT_USE_STRONG_TYPING}")
 message(STATUS "CDT_DEVELOPER_BUILD is ${CDT_DEVELOPER_BUILD}")
-
-if(CDT_USE_STRONG_TYPING)
-    set(CDT_USE_BOOST ON)
-endif()
 
 # Use boost for c++98 versions of c++11 containers or for Boost::rtree
 if(CDT_USE_BOOST)
@@ -155,8 +148,12 @@ target_compile_definitions(
 )
 
 if(CDT_USE_BOOST)
-    target_link_libraries(${PROJECT_NAME} INTERFACE Boost::boost)
-endif()
+    if(CDT_USE_AS_COMPILED_LIBRARY)
+        target_link_libraries(${PROJECT_NAME} PUBLIC Boost::boost)
+    else ()
+        target_link_libraries(${PROJECT_NAME} INTERFACE Boost::boost)
+    endif ()
+endif ()
 
 
 # -------------

--- a/docs/README.md
+++ b/docs/README.md
@@ -94,9 +94,7 @@ when at least one vertex belongs to super-triangle are resolved using an approac
 
 - Uses William C. Lenthe's implementation of robust orientation and in-circle geometric predicates: [github.com/wlenthe/GeometricPredicates](https://github.com/wlenthe/GeometricPredicates)
 
-- Boost is an optional (to opt-in define `CDT_USE_BOOST`) dependency used for:
-    * **Fall back** for standard library features missing in C++98 compilers.
-    * **Minor performance tweaks:** `boost::container::flat_set` is used for faster triangle walking.
+- On old compilers without C++11 support Boost is used as a fall back for missing C++11 standard library features.
 
 - A demonstrator tool is included: requires Qt for GUI. When running demo-tool **make sure** that working directory contains files from 'data' folder.
 
@@ -114,7 +112,6 @@ CDT uses modern CMake and should *just work* out of the box without any suprises
 
 | Option                      | Default value | Description                                                                                           |
 | --------------------------- | :-----------: | :---------------------------------------------------------------------------------------------------- |
-| CDT_USE_BOOST               |      OFF      | Use Boost as a fall-back for features missing in C++98 and performance tweaks (e.g., `boost::flat_set`) |
 | CDT_USE_64_BIT_INDEX_TYPE   |      OFF      | Use 64bits to store vertex/triangle index types. Otherwise 32bits are used (up to 4.2bn items)        |
 | CDT_USE_AS_COMPILED_LIBRARY |      OFF      | Instantiate templates for float and double and compiled into a library                                |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -136,7 +136,7 @@ CDT provides package config files that can be included by other projects to find
 # from CDT folder
 mkdir build && cd build
 # configure with desired CMake flags
-cmake -DCDT_USE_AS_COMPILED_LIBRARY=ON -DCDT_USE_BOOST=ON ..
+cmake -DCDT_USE_AS_COMPILED_LIBRARY=ON ..
 # build and install
 cmake --build . && cmake --install .
 ```


### PR DESCRIPTION
Update readme and cmake to better reflect how boost is used in CDT (only when compiling with C++98)