### PR TITLE
Implement disabling exceptions

### DIFF
--- a/CDT/CMakeLists.txt
+++ b/CDT/CMakeLists.txt
@@ -36,7 +36,7 @@ option(CDT_DEVELOPER_BUILD
     OFF)
 
 option(CDT_DISABLE_EXCEPTIONS
-    "Disables exceptions in the library: instead of throwing the library will call std::terminate"
+    "Disables exceptions: instead of throwing the library will call `std::terminate`"
     OFF)
 
 if(CDT_DEVELOPER_BUILD)

--- a/CDT/CMakeLists.txt
+++ b/CDT/CMakeLists.txt
@@ -35,6 +35,10 @@ option(CDT_DEVELOPER_BUILD
     "Enables all warnings."
     OFF)
 
+option(CDT_DISABLE_EXCEPTIONS
+    "Disables exceptions in the library: instead of throwing the library will call std::terminate"
+    OFF)
+
 if(CDT_DEVELOPER_BUILD)
     if (MSVC)
         # warning level 4 and all warnings as errors
@@ -66,6 +70,7 @@ message(STATUS "CDT_USE_64_BIT_INDEX_TYPE is ${CDT_USE_64_BIT_INDEX_TYPE}")
 message(STATUS "CDT_ENABLE_TESTING is ${CDT_ENABLE_TESTING}")
 message(STATUS "CDT_USE_STRONG_TYPING is ${CDT_USE_STRONG_TYPING}")
 message(STATUS "CDT_DEVELOPER_BUILD is ${CDT_DEVELOPER_BUILD}")
+message(STATUS "CDT_DISABLE_EXCEPTIONS is ${CDT_DISABLE_EXCEPTIONS}")
 
 # Use boost for c++98 versions of c++11 containers or for Boost::rtree
 if(CDT_USE_BOOST)
@@ -145,6 +150,7 @@ target_compile_definitions(
         $<$<BOOL:${CDT_USE_AS_COMPILED_LIBRARY}>:CDT_USE_AS_COMPILED_LIBRARY>
         $<$<BOOL:${CDT_USE_64_BIT_INDEX_TYPE}>:CDT_USE_64_BIT_INDEX_TYPE>
         $<$<BOOL:${CDT_USE_STRONG_TYPING}>:CDT_USE_STRONG_TYPING>
+        $<$<BOOL:${CDT_DISABLE_EXCEPTIONS}>:CDT_DISABLE_EXCEPTIONS>
 )
 
 target_link_libraries(${PROJECT_NAME} ${cdt_scope} $<$<BOOL:${CDT_USE_BOOST}>:Boost::boost>)

--- a/CDT/include/CDTUtils.h
+++ b/CDT/include/CDTUtils.h
@@ -60,6 +60,10 @@ typedef char couldnt_parse_cxx_standard[-1]; ///< Error: couldn't parse standard
 #include <unordered_map>
 #include <unordered_set>
 
+#ifdef CDT_DISABLE_EXCEPTIONS
+#include <exception>
+#endif
+
 namespace CDT
 {
 using std::array;
@@ -99,6 +103,16 @@ std::string to_string(const T& value)
 
 namespace CDT
 {
+
+template <typename T>
+void handleException(const T& error)
+{
+#ifdef CDT_DISABLE_EXCEPTIONS
+    std::terminate();
+#else
+    throw error;
+#endif
+}
 
 /// Needed for c++03 compatibility (no uniform initialization available)
 template <typename T>
@@ -180,15 +194,17 @@ typedef IndexSizeType TriInd;
 #endif
 
 /// Constant representing no valid value for index
+const static Index invalidIndex(std::numeric_limits<Index>::max());
+/// Constant representing no valid value for index size
 const static IndexSizeType
-    invalidIndex(std::numeric_limits<IndexSizeType>::max());
+    invalidIndexSizeType(std::numeric_limits<IndexSizeType>::max());
 /// Number of super triangle vertices
 /// @note placed in a constant so that it's easier to find usages in code
 const static IndexSizeType nSuperTriangleVertices(3);
 /// Constant representing no valid neighbor for a triangle
-const static TriInd noNeighbor(invalidIndex);
+const static TriInd noNeighbor(invalidIndexSizeType);
 /// Constant representing no valid vertex for a triangle
-const static VertInd noVertex(invalidIndex);
+const static VertInd noVertex(invalidIndexSizeType);
 
 typedef std::vector<TriInd> TriIndVec;  ///< Vector of triangle indices
 typedef array<VertInd, 3> VerticesArr3; ///< array of three vertex indices

--- a/CDT/include/CDTUtils.hpp
+++ b/CDT/include/CDTUtils.hpp
@@ -108,7 +108,8 @@ CDT_INLINE_IF_HEADER_ONLY Index opoNbr(const Index vertIndex)
     if(vertIndex == Index(2))
         return Index(0);
     assert(false && "Invalid vertex index");
-    throw std::runtime_error("Invalid vertex index");
+    handleException(std::runtime_error("Invalid vertex index"));
+    return invalidIndex;
 }
 
 CDT_INLINE_IF_HEADER_ONLY Index opoVrt(const Index neighborIndex)
@@ -120,7 +121,8 @@ CDT_INLINE_IF_HEADER_ONLY Index opoVrt(const Index neighborIndex)
     if(neighborIndex == Index(2))
         return Index(1);
     assert(false && "Invalid neighbor index");
-    throw std::runtime_error("Invalid neighbor index");
+    handleException(std::runtime_error("Invalid neighbor index"));
+    return invalidIndex;
 }
 
 CDT_INLINE_IF_HEADER_ONLY Index

--- a/CDT/include/Triangulation.h
+++ b/CDT/include/Triangulation.h
@@ -832,7 +832,7 @@ void Triangulation<T, TNearPointLocator>::insertVertices(
     TGetVertexCoordY getY)
 {
     if(isFinalized())
-        throw FinalizedError(CDT_SOURCE_LOCATION);
+        handleException(FinalizedError(CDT_SOURCE_LOCATION));
 
     const bool isFirstTime = vertices.empty();
 
@@ -909,7 +909,7 @@ void Triangulation<T, TNearPointLocator>::insertEdges(
     TGetEdgeVertexEnd getEnd)
 {
     if(isFinalized())
-        throw FinalizedError(CDT_SOURCE_LOCATION);
+        handleException(FinalizedError(CDT_SOURCE_LOCATION));
 
     std::vector<TriangulatePseudoPolygonTask> tppIterations;
     EdgeVec remaining;
@@ -935,7 +935,7 @@ void Triangulation<T, TNearPointLocator>::conformToEdges(
     TGetEdgeVertexEnd getEnd)
 {
     if(isFinalized())
-        throw FinalizedError(CDT_SOURCE_LOCATION);
+        handleException(FinalizedError(CDT_SOURCE_LOCATION));
 
     tryInitNearestPointLocator();
     // state shared between different runs for performance gains

--- a/CDT/include/Triangulation.hpp
+++ b/CDT/include/Triangulation.hpp
@@ -521,11 +521,11 @@ void Triangulation<T, TNearPointLocator>::insertEdgeIteration(
                 // don't count super-triangle vertices
                 e1 = Edge(e1.v1() - m_nTargetVerts, e1.v2() - m_nTargetVerts);
                 e2 = Edge(e2.v1() - m_nTargetVerts, e2.v2() - m_nTargetVerts);
-                throw IntersectingConstraintsError(
+                handleException(IntersectingConstraintsError(
                     e1,
                     pieceToOriginals.count(e2) ? pieceToOriginals.at(e2).front()
                                                : e2,
-                    CDT_SOURCE_LOCATION);
+                    CDT_SOURCE_LOCATION));
             }
             break;
         case IntersectingConstraintEdges::TryResolve: {
@@ -716,7 +716,8 @@ void Triangulation<T, TNearPointLocator>::conformToEdgeIteration(
                 // don't count super-triangle vertices
                 e1 = Edge(e1.v1() - m_nTargetVerts, e1.v2() - m_nTargetVerts);
                 e2 = Edge(e2.v1() - m_nTargetVerts, e2.v2() - m_nTargetVerts);
-                throw IntersectingConstraintsError(e1, e2, CDT_SOURCE_LOCATION);
+                handleException(
+                    IntersectingConstraintsError(e1, e2, CDT_SOURCE_LOCATION));
             }
             break;
         case IntersectingConstraintEdges::TryResolve: {
@@ -914,9 +915,10 @@ Triangulation<T, TNearPointLocator>::intersectedTriangle(
         iT = t.next(iA).first;
     } while(iT != startTri);
 
-    throw Error(
+    handleException(Error(
         "Could not find vertex triangle intersected by an edge.",
-        CDT_SOURCE_LOCATION);
+        CDT_SOURCE_LOCATION));
+    return make_tuple(noNeighbor, noVertex, noVertex);
 }
 
 template <typename T, typename TNearPointLocator>
@@ -1379,7 +1381,9 @@ Triangulation<T, TNearPointLocator>::trianglesAt(const V2d<T>& pos) const
             out[1] = t.neighbors[edgeNeighbor(loc)];
         return out;
     }
-    throw Error("No triangle was found at position", CDT_SOURCE_LOCATION);
+    handleException(
+        Error("No triangle was found at position", CDT_SOURCE_LOCATION));
+    return out;
 }
 
 template <typename T, typename TNearPointLocator>
@@ -1432,14 +1436,17 @@ array<TriInd, 2> Triangulation<T, TNearPointLocator>::walkingSearchTrianglesAt(
     const PtTriLocation::Enum loc = locatePointTriangle(v, v1, v2, v3);
 
     if(loc == PtTriLocation::Outside)
-        throw Error("No triangle was found at position", CDT_SOURCE_LOCATION);
+    {
+        handleException(
+            Error("No triangle was found at position", CDT_SOURCE_LOCATION));
+    }
     if(loc == PtTriLocation::OnVertex)
     {
         const VertInd iDupe = v1 == v   ? t.vertices[0]
                               : v2 == v ? t.vertices[1]
                                         : t.vertices[2];
-        throw DuplicateVertexError(
-            iV - m_nTargetVerts, iDupe - m_nTargetVerts, CDT_SOURCE_LOCATION);
+        handleException(DuplicateVertexError(
+            iV - m_nTargetVerts, iDupe - m_nTargetVerts, CDT_SOURCE_LOCATION));
     }
 
     out[0] = iT;
@@ -1974,7 +1981,7 @@ std::pair<TriInd, TriInd> Triangulation<T, TNearPointLocator>::edgeTriangles(
         }
         iT = iTNext;
     } while(iT != triStart);
-    return std::make_pair(invalidIndex, invalidIndex);
+    return std::make_pair(invalidIndexSizeType, invalidIndexSizeType);
 }
 
 template <typename T, typename TNearPointLocator>
@@ -1982,7 +1989,7 @@ bool Triangulation<T, TNearPointLocator>::hasEdge(
     const VertInd a,
     const VertInd b) const
 {
-    return edgeTriangles(a, b).first != invalidIndex;
+    return edgeTriangles(a, b).first != invalidIndexSizeType;
 }
 
 template <typename T, typename TNearPointLocator>

--- a/docs/README.md
+++ b/docs/README.md
@@ -126,10 +126,11 @@ CDT uses modern CMake and should *just work* out of the box without any surprise
 
 **CMake options**
 
-| Option                      | Default value | Description                                                                                           |
-| --------------------------- | :-----------: | :---------------------------------------------------------------------------------------------------- |
-| CDT_USE_64_BIT_INDEX_TYPE   |      OFF      | Use 64bits to store vertex/triangle index types. Otherwise 32bits are used (up to 4.2bn items)        |
-| CDT_USE_AS_COMPILED_LIBRARY |      OFF      | Instantiate templates for float and double and compiled into a library                                |
+| Option                        | Default value | Description                                                                                    |
+|-------------------------------| :-----------: |:-----------------------------------------------------------------------------------------------|
+| `CDT_USE_64_BIT_INDEX_TYPE`   |      `OFF`      | Use 64bits to store vertex/triangle index types. Otherwise 32bits are used (up to 4.2bn items) |
+| `CDT_USE_AS_COMPILED_LIBRARY` |      `OFF`      | Instantiate templates for float and double and compiled into a library                         |
+| `CDT_DISABLE_EXCEPTIONS`      |      `OFF`      | Disables exceptions: instead of throwing the library will call `std::terminate`                |
 
 **Adding to CMake project directly**
 


### PR DESCRIPTION
Solves issue #194 

#### Implement option to disable exceptions in CDT

In some contexts it is desirable to disable throwing exceptions in CDT.
Exceptions can be disabled in CMake or as a macro: `CDT_DISABLE_EXCEPTIONS`
When `CDT_DISABLE_EXCEPTIONS` is `ON`: Instead of throwing program shall terminate.