### PR TITLE
#200 Fix KDTree

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -33,7 +33,8 @@ UseTab: Never
 # Clang 5 new features:
 # =====================
 BreakBeforeBraces: Custom
-BraceWrapping: 
+BraceWrapping:
+    AfterCaseLabel: true
     AfterClass: true
     AfterControlStatement: true
     AfterEnum : true

--- a/CDT/include/Triangulation.h
+++ b/CDT/include/Triangulation.h
@@ -289,6 +289,11 @@ struct CDT_EXPORT TriangleChangeType
     };
 };
 
+// parameter names are used for documentation purposes, even if they are un-used
+// in the interface's default implementation
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+
 /**
  * Interface for the callback handler that user can derive from and inject into
  * the triangulation to monitor certain events or order aborting the calculation
@@ -383,6 +388,10 @@ public:
         return false;
     };
 };
+
+// parameter names are used for documentation purposes, even if they are
+// un-used in the interface's default implementation
+#pragma GCC diagnostic pop
 
 #endif
 

--- a/CDT/src/CDT.cpp
+++ b/CDT/src/CDT.cpp
@@ -65,6 +65,16 @@ template CDT_EXPORT void initializeWithRegularGrid<double>(
     std::size_t,
     Triangulation<double>&);
 
+template
+CDT_EXPORT float distance(const V2d<float>& a, const V2d<float>& b);
+template
+CDT_EXPORT double distance(const V2d<double>& a, const V2d<double>& b);
+
+template
+CDT_EXPORT float distanceSquared(const V2d<float>& a, const V2d<float>& b);
+template
+CDT_EXPORT double distanceSquared(const V2d<double>& a, const V2d<double>& b);
+
 } // namespace CDT
 
 #endif

--- a/CDT/tests/cdt.test.cpp
+++ b/CDT/tests/cdt.test.cpp
@@ -1113,4 +1113,29 @@ TEST_CASE("Callbacks test: test aborting the calculation")
         }
     }
 }
+
 #endif
+
+TEST_CASE("KDtree regression (#200)")
+{
+    const auto target = V2d<double>(153.63, -30.09);
+    const auto points = std::vector<V2d<double> >{
+        V2d<double>(168.67, -122.39), // approx distance to target: 93.52
+        V2d<double>(-25.12, 109.06),  // approx distance to target: 226.53
+        V2d<double>(178.36, 40.75),   // approx distance to target: 75.03
+        V2d<double>(161.07, 86.2),    // approx distance to target: 116.53
+    };
+
+    auto tree = KDTree::KDTree<double, 1, 32, 32>(
+        V2d<double>(-180, -180), V2d<double>(180, 180));
+    double min_distance = std::numeric_limits<double>::max();
+    for(VertInd i(0); i < points.size(); ++i)
+    {
+        tree.insert(i, points);
+        min_distance = std::min(min_distance, distance(target, points[i]));
+    }
+
+    const auto [matchVec, matchIdx] = tree.nearest(target, points);
+    REQUIRE(min_distance == distance(target, points[matchIdx]));
+}
+

--- a/CDT/tests/cdt.test.cpp
+++ b/CDT/tests/cdt.test.cpp
@@ -961,6 +961,7 @@ TEST_CASE("Regression test #174: super-triangle of tiny bounding box", "")
 }
 
 #ifdef CDT_ENABLE_CALLBACK_HANDLER
+
 TEST_CASE("Callbacks test: count number of callback calls")
 {
     auto [vv, ee] = readInputFromFile<double>("inputs/Capital A.txt");
@@ -1139,3 +1140,34 @@ TEST_CASE("KDtree regression (#200)")
     REQUIRE(min_distance == distance(target, points[matchIdx]));
 }
 
+TEST_CASE("KDtree nearest point query", "[KDTree]")
+{
+    using Coord = double;
+    using Point = V2d<Coord>;
+
+    std::vector<Point> points = {
+        {0.0, 0.0}, {1.0, 1.0}, {2.0, 2.0}, {3.0, 3.0}};
+
+    KDTree::KDTree<Coord, 1, 32, 32> tree;
+    for(VertInd i(0); i < points.size(); ++i)
+        tree.insert(i, points);
+
+    SECTION("Exact match")
+    {
+        auto result = tree.nearest(Point{1.0, 1.0}, points);
+        REQUIRE(result.second == 1);
+        REQUIRE(result.first == Point{1.0, 1.0});
+    }
+
+    SECTION("Nearest to midpoint")
+    {
+        auto result = tree.nearest(Point{1.4, 1.4}, points);
+        REQUIRE(result.second == 1); // Closest to point {1.0, 1.0}
+    }
+
+    SECTION("Nearest at the edge")
+    {
+        auto result = tree.nearest(Point{3.1, 3.1}, points);
+        REQUIRE(result.second == 3); // Closest to point {3.0, 3.0}
+    }
+}

--- a/CDT/tests/cdt.test.cpp
+++ b/CDT/tests/cdt.test.cpp
@@ -967,6 +967,10 @@ TEST_CASE("Callbacks test: count number of callback calls")
     auto cdt = Triangulation<double>();
     // REQUIRE(sizeof(cdt) == 368);
 
+// parameter names are used for documentation purposes, even if they are un-used
+// in the interface's default implementation
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
     struct CallbackHandler final : public CDT::ICallbackHandler
     {
         void onAddSuperTriangle() override
@@ -1016,11 +1020,16 @@ TEST_CASE("Callbacks test: count number of callback calls")
             nModifiedTriangles += tris.size();
         }
 
-        int nAddedVertices = 0;
-        int nModifiedTriangles = 0;
-        int nAddedTriangles = 0;
-        int nAddedEdges = 0;
+        std::size_t nAddedVertices = 0;
+        std::size_t nModifiedTriangles = 0;
+        std::size_t nAddedTriangles = 0;
+        std::size_t nAddedEdges = 0;
     };
+
+// parameter names are used for documentation purposes, even if they are
+// un-used in the interface's default implementation
+#pragma GCC diagnostic pop
+
     CallbackHandler callbackHandler;
     cdt.setCallbackHandler(&callbackHandler);
 
@@ -1073,7 +1082,7 @@ TEST_CASE("Callbacks test: test aborting the calculation")
     {
         struct CallbackHandler final : public CDT::ICallbackHandler
         {
-            void onAddEdgeStart(const Edge& edge) override
+            void onAddEdgeStart(const Edge& /*edge*/) override
             {
                 ++n;
             }


### PR DESCRIPTION
Fixes bugs in KDTree:
- extending KDTree had a bug when point was outside bounding box but not in the direction of root's split axis
- `nearest` method had incorrect distance to bounding box calculations. Now we re-use parent distance for closest child and calculate farther child's distance efficiently (knowing that point is on the other side of split axis) 