### PR TITLE
Fix inserting vertex directly on fixed edge

### DIFF
--- a/CDT/include/Triangulation.h
+++ b/CDT/include/Triangulation.h
@@ -809,7 +809,11 @@ private:
     /// Returns indices of three resulting triangles
     std::stack<TriInd> insertVertexInsideTriangle(VertInd v, TriInd iT);
     /// Returns indices of four resulting triangles
-    std::stack<TriInd> insertVertexOnEdge(VertInd v, TriInd iT1, TriInd iT2);
+    std::stack<TriInd> insertVertexOnEdge(
+        VertInd v,
+        TriInd iT1,
+        TriInd iT2,
+        const bool doHandleFixedSplitEdge = false);
     array<TriInd, 2> trianglesAt(const V2d<T>& pos) const;
     array<TriInd, 2>
     walkingSearchTrianglesAt(VertInd iV, VertInd startVertex) const;

--- a/CDT/include/Triangulation.hpp
+++ b/CDT/include/Triangulation.hpp
@@ -1100,7 +1100,7 @@ void Triangulation<T, TNearPointLocator>::insertVertex(
     std::stack<TriInd> triStack =
         trisAt[1] == noNeighbor
             ? insertVertexInsideTriangle(iVert, trisAt[0])
-            : insertVertexOnEdge(iVert, trisAt[0], trisAt[1]);
+            : insertVertexOnEdge(iVert, trisAt[0], trisAt[1], true);
     ensureDelaunayByEdgeFlips(iVert, triStack);
 }
 
@@ -1477,7 +1477,8 @@ template <typename T, typename TNearPointLocator>
 std::stack<TriInd> Triangulation<T, TNearPointLocator>::insertVertexOnEdge(
     VertInd v,
     TriInd iT1,
-    TriInd iT2)
+    TriInd iT2,
+    const bool doHandleFixedSplitEdge)
 {
     const TriInd iTnew1 = addTriangle();
     const TriInd iTnew2 = addTriangle();
@@ -1512,6 +1513,13 @@ std::stack<TriInd> Triangulation<T, TNearPointLocator>::insertVertexOnEdge(
     // adjust neighboring triangles and vertices
     changeNeighbor(n4, iT1, iTnew1);
     changeNeighbor(n3, iT2, iTnew2);
+    // properly handle the case when the split edge is a fixed edge
+    if(doHandleFixedSplitEdge)
+    {
+        const Edge sharedEdge(v2, v4);
+        if(fixedEdges.count(sharedEdge))
+            splitFixedEdge(sharedEdge, v);
+    }
     // return newly added triangles
     std::stack<TriInd> newTriangles;
     newTriangles.push(iT1);

--- a/CDT/include/Triangulation.hpp
+++ b/CDT/include/Triangulation.hpp
@@ -554,7 +554,8 @@ void Triangulation<T, TNearPointLocator>::insertEdgeIteration(
                     CDT_SOURCE_LOCATION));
             }
             break;
-        case IntersectingConstraintEdges::TryResolve: {
+        case IntersectingConstraintEdges::TryResolve:
+        {
             if(!fixedEdges.count(Edge(iVL, iVR)))
                 break;
             // split edge at the intersection of two constraint edges
@@ -765,7 +766,8 @@ void Triangulation<T, TNearPointLocator>::conformToEdgeIteration(
                     IntersectingConstraintsError(e1, e2, CDT_SOURCE_LOCATION));
             }
             break;
-        case IntersectingConstraintEdges::TryResolve: {
+        case IntersectingConstraintEdges::TryResolve:
+        {
             if(!fixedEdges.count(Edge(iVleft, iVright)))
                 break;
             // split edge at the intersection of two constraint edges

--- a/CDT/tests/cdt.test.cpp
+++ b/CDT/tests/cdt.test.cpp
@@ -1211,3 +1211,42 @@ TEST_CASE("KDTree nearest stress test", "[KDTree]")
         REQUIRE(nearestIdx == expectedIdx);
     }
 }
+
+TEST_CASE("Regression test #204: inserting vertex on fixed edge", "")
+{
+    auto cdt = Triangulation<double>{};
+
+    REQUIRE_NOTHROW(cdt.insertVertices(
+        Vertices<double>{
+            {
+                {0., 0.},
+                {2., 0.},
+            },
+        }));
+    cdt.insertEdges(std::vector<Edge>{{0, 1}});
+
+    REQUIRE_NOTHROW(cdt.insertVertices(
+        Vertices<double>{
+            {
+                {1., 0.},
+                {1., 2.},
+            },
+        }));
+    cdt.insertEdges(
+        std::vector<Edge>{
+            {2, 3},
+        });
+
+    REQUIRE(CDT::verifyTopology(cdt));
+    cdt.eraseSuperTriangle();
+    REQUIRE(cdt.triangles.size() == std::size_t(2));
+    REQUIRE(cdt.fixedEdges.size() == std::size_t(3));
+    REQUIRE(cdt.fixedEdges.count(Edge(0, 2)));
+    REQUIRE(cdt.fixedEdges.count(Edge(1, 2)));
+    REQUIRE(cdt.fixedEdges.count(Edge(2, 3)));
+
+    REQUIRE(cdt.pieceToOriginals.at(Edge(0, 2)).size() == 1);
+    REQUIRE(cdt.pieceToOriginals.at(Edge(1, 2)).size() == 1);
+    REQUIRE(cdt.pieceToOriginals.at(Edge(0, 2))[0] == Edge(0, 1));
+    REQUIRE(cdt.pieceToOriginals.at(Edge(1, 2))[0] == Edge(0, 1));
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -287,6 +287,7 @@ For Python bindings check-out [PythonCDT](https://github.com/artem-ogre/PythonCD
 - [Som1Lse](https://github.com/Som1Lse): fuzzing CDT: finding, reproducing, and reporting bugs ([#154](https://github.com/artem-ogre/CDT/issues/148))
 - [Madrich](https://github.com/Madrich): help with implementing user callbacks ([#178](https://github.com/artem-ogre/CDT/issues/178))
 - [davidkellerman](https://github.com/davidkellerman): finding and reproducing bug in KDTree's `nearest` method ([#200](https://github.com/artem-ogre/CDT/issues/200))
+- [Boris Clémençon](https://github.com/borisclemencon): finding and reproducing, and reporting a bug ([#204](https://github.com/artem-ogre/CDT/issues/204))
 
 <a name="contributing"></a>
 


### PR DESCRIPTION
**Description**
When interleaving multiple calls to `insertVertices` and `insertEdges` it is possible that the vertex splits fixed edge.
The code did not handle the case properly: triangles were split but fixed edges were not updated.
  
**Changes**
- **Fix:** when inserting vertex on the edge check if edge is fixed and do all the necessary bookkeeping.
- Regression test added.