### PR TITLE
Add include guards to .hpp implementation files; default TNearPointLocator

### DIFF
--- a/CDT/extras/VerifyTopology.h
+++ b/CDT/extras/VerifyTopology.h
@@ -28,7 +28,7 @@ namespace CDT
  * @tparam T type of vertex coordinates (e.g., float, double)
  * @tparam TNearPointLocator class providing locating near point for efficiently
  */
-template <typename T, typename TNearPointLocator>
+template <typename T, typename TNearPointLocator = LocatorKDTree<T> >
 inline bool verifyTopology(const CDT::Triangulation<T, TNearPointLocator>& cdt)
 {
     // Check if vertices' adjacent triangles contain vertex
@@ -75,7 +75,7 @@ inline bool verifyTopology(const CDT::Triangulation<T, TNearPointLocator>& cdt)
 }
 
 /// Check that each vertex has a neighbor triangle
-template <typename T, typename TNearPointLocator>
+template <typename T, typename TNearPointLocator = LocatorKDTree<T> >
 inline bool eachVertexHasNeighborTriangle(
     const CDT::Triangulation<T, TNearPointLocator>& cdt)
 {

--- a/CDT/include/CDT.hpp
+++ b/CDT/include/CDT.hpp
@@ -6,6 +6,8 @@
  * @file
  * Public API - implementation
  */
+#ifndef CDT_WbKVsqQQaFWUcDDZzmmC
+#define CDT_WbKVsqQQaFWUcDDZzmmC
 
 #include "CDT.h"
 
@@ -105,3 +107,5 @@ EdgeToPiecesMapping(const unordered_map<Edge, EdgeVec>& pieceToOriginals)
 }
 
 } // namespace CDT
+
+#endif // header-guard

--- a/CDT/include/CDTUtils.hpp
+++ b/CDT/include/CDTUtils.hpp
@@ -6,6 +6,8 @@
  * @file
  * Utilities and helpers - implementation
  */
+#ifndef CDT_zWlHcbQZQyBBqPgxvFDT
+#define CDT_zWlHcbQZQyBBqPgxvFDT
 
 #include "CDTUtils.h"
 
@@ -262,3 +264,5 @@ bool touchesSuperTriangle(const Triangle& t)
 }
 
 } // namespace CDT
+
+#endif // header-guard

--- a/CDT/include/Triangulation.hpp
+++ b/CDT/include/Triangulation.hpp
@@ -6,6 +6,8 @@
  * @file
  * Triangulation class - implementation
  */
+#ifndef CDT_pDqrlveWIOrIWeUCkPqX
+#define CDT_pDqrlveWIOrIWeUCkPqX
 
 #include "Triangulation.h"
 #include "portable_nth_element.hpp"
@@ -2176,3 +2178,5 @@ void Triangulation<T, TNearPointLocator>::tryInitNearestPointLocator()
 }
 
 } // namespace CDT
+
+#endif // header-guard


### PR DESCRIPTION
Directly including a .hpp implementation file alongside its .h counterpart in the same translation unit (header-only mode) causes redefinition errors, since only the .h files were guarded. This was independently hit and worked around in at least three community forks. Guarding the .hpp files makes direct inclusion harmless instead of a compile error.

Also default TNearPointLocator to LocatorKDTree<T> in verifyTopology and eachVertexHasNeighborTriangle, matching Triangulation's own default, so callers don't have to spell out the locator type.