### PR TITLE
Restore c++98 compatibility and check all standards in CI

### DIFF
--- a/.github/workflows/ci_builds.yml
+++ b/.github/workflows/ci_builds.yml
@@ -48,3 +48,83 @@ jobs:
       run: conan create CDT/ -o use_boost=True -o enable_testing=True --build missing
     - name: "Build: header-only, without boost, with callbacks"
       run: conan create CDT/ -o use_boost=False -o enable_testing=True -o enable_callback_handler=True
+
+  standards:
+    name: "C++${{ matrix.std }} (${{ matrix.cxx }})"
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        # oldest supported standard: Boost stands in for the c++11 features
+        - std: 98
+          cxx: g++-13
+          boost: "ON"
+        - std: 11
+          cxx: g++-13
+          boost: "OFF"
+        - std: 14
+          cxx: g++-13
+          boost: "OFF"
+        - std: 17
+          cxx: g++-13
+          boost: "OFF"
+        - std: 20
+          cxx: g++-13
+          boost: "OFF"
+        - std: 23
+          cxx: g++-13
+          boost: "OFF"
+        # newest standard: g++-13 does not know -std=c++26
+        - std: 26
+          cxx: g++-14
+          boost: "OFF"
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
+
+    - name: Install compiler
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y ${{ matrix.cxx }}
+
+    - name: Install Conan and fetch Boost
+      if: matrix.boost == 'ON'
+      run: |
+        python -m pip install --upgrade pip
+        pip install conan
+        conan profile detect
+        conan install --requires=boost/1.83.0 -o "boost/*:header_only=True" \
+          -g CMakeDeps --output-folder=boost-dep --build=missing
+
+    - name: "Header-only: build and run"
+      run: |
+        cmake -S CDT -B build-header-only \
+          -DCMAKE_CXX_COMPILER=${{ matrix.cxx }} \
+          -DCMAKE_CXX_STANDARD=${{ matrix.std }} \
+          -DCMAKE_CXX_STANDARD_REQUIRED=ON \
+          -DCMAKE_PREFIX_PATH="$PWD/boost-dep" \
+          -DCDT_USE_BOOST=${{ matrix.boost }} \
+          -DCDT_ENABLE_STANDARDS_CHECK=ON \
+          -DCMAKE_BUILD_TYPE=Release
+        cmake --build build-header-only -j
+        ./build-header-only/CDT-standards-check
+
+    - name: "Compiled library: build and run"
+      run: |
+        cmake -S CDT -B build-compiled \
+          -DCMAKE_CXX_COMPILER=${{ matrix.cxx }} \
+          -DCMAKE_CXX_STANDARD=${{ matrix.std }} \
+          -DCMAKE_CXX_STANDARD_REQUIRED=ON \
+          -DCMAKE_PREFIX_PATH="$PWD/boost-dep" \
+          -DCDT_USE_BOOST=${{ matrix.boost }} \
+          -DCDT_USE_AS_COMPILED_LIBRARY=ON \
+          -DCDT_ENABLE_STANDARDS_CHECK=ON \
+          -DCMAKE_BUILD_TYPE=Release
+        cmake --build build-compiled -j
+        ./build-compiled/CDT-standards-check

--- a/CDT/CMakeLists.txt
+++ b/CDT/CMakeLists.txt
@@ -31,6 +31,10 @@ option(CDT_ENABLE_TESTING
     "If enabled tests target will ge generated)"
     OFF)
 
+option(CDT_ENABLE_STANDARDS_CHECK
+    "If enabled a small program instantiating the public API is generated: used to check that CDT builds with every supported C++ standard"
+    OFF)
+
 option(CDT_USE_STRONG_TYPING
     "If enabled uses strong typing for types: useful for development and debugging"
     OFF)
@@ -73,6 +77,7 @@ message(STATUS "CDT_USE_AS_COMPILED_LIBRARY is ${CDT_USE_AS_COMPILED_LIBRARY}")
 message(STATUS "CDT_USE_64_BIT_INDEX_TYPE is ${CDT_USE_64_BIT_INDEX_TYPE}")
 message(STATUS "CDT_ENABLE_CALLBACK_HANDLER is ${CDT_ENABLE_CALLBACK_HANDLER}")
 message(STATUS "CDT_ENABLE_TESTING is ${CDT_ENABLE_TESTING}")
+message(STATUS "CDT_ENABLE_STANDARDS_CHECK is ${CDT_ENABLE_STANDARDS_CHECK}")
 message(STATUS "CDT_USE_STRONG_TYPING is ${CDT_USE_STRONG_TYPING}")
 message(STATUS "CDT_DEVELOPER_BUILD is ${CDT_DEVELOPER_BUILD}")
 message(STATUS "CDT_DISABLE_EXCEPTIONS is ${CDT_DISABLE_EXCEPTIONS}")
@@ -283,4 +288,17 @@ if(CDT_ENABLE_TESTING)
     )
     include(Catch)
     catch_discover_tests(${TEST_TARGET_NAME} WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/tests")
+endif()
+
+# -----------------
+# standards check
+# -----------------
+
+# Unlike the tests (which are built as c++17 because of Catch2) this target
+# follows CMAKE_CXX_STANDARD, so it can be built with every standard CDT
+# supports, down to c++98.
+if(CDT_ENABLE_STANDARDS_CHECK)
+    set(STANDARDS_CHECK_TARGET_NAME ${PROJECT_NAME}-standards-check)
+    add_executable(${STANDARDS_CHECK_TARGET_NAME} tests/standards_check.cpp)
+    target_link_libraries(${STANDARDS_CHECK_TARGET_NAME} PRIVATE CDT::CDT)
 endif()

--- a/CDT/extras/InitializeWithGrid.h
+++ b/CDT/extras/InitializeWithGrid.h
@@ -14,9 +14,7 @@
 #include <CDT.h>
 #include <CDTUtils.h>
 
-#ifdef CDT_CXX11_IS_SUPPORTED
 #include <algorithm>
-#endif
 #include <cstddef>
 #include <iterator>
 #include <vector>
@@ -88,11 +86,8 @@ void generateGridVertices(
                 vTris.push_back(static_cast<TriInd>(2 * (i - xres)));
                 vTris.push_back(static_cast<TriInd>(2 * (i - xres) + 1));
             }
-#ifdef CDT_CXX11_IS_SUPPORTED
-            *outTrisFirst++ = std::move(vTris.front());
-#else
-            *outTrisFirst++ = vTris;
-#endif
+            // note: only one adjacent triangle per vertex is stored
+            *outTrisFirst++ = vTris.front();
         }
     }
 }
@@ -128,19 +123,21 @@ void generateGridTriangles(
                 VertInd(iv + xres + 1),
                 VertInd(iv + xres + 2)};
             {
-                const Triangle t = {
-                    {vv[0], vv[1], vv[2]},
-                    {TriInd(iy ? 2 * i - xres * 2 + 1 : noNeighbor),
-                     TriInd(2 * i + 1),
-                     TriInd(ix ? 2 * i - 1 : noNeighbor)}};
+                const Triangle t(
+                    arr3(vv[0], vv[1], vv[2]),
+                    arr3(
+                        TriInd(iy ? 2 * i - xres * 2 + 1 : noNeighbor),
+                        TriInd(2 * i + 1),
+                        TriInd(ix ? 2 * i - 1 : noNeighbor)));
                 *outFirst++ = t;
             }
             {
-                const Triangle t = {
-                    {vv[1], vv[3], vv[2]},
-                    {TriInd(ix < xres - 1 ? 2 * i + 2 : noNeighbor),
-                     TriInd(iy < yres - 1 ? 2 * i + xres * 2 : noNeighbor),
-                     TriInd(2 * i)}};
+                const Triangle t(
+                    arr3(vv[1], vv[3], vv[2]),
+                    arr3(
+                        TriInd(ix < xres - 1 ? 2 * i + 2 : noNeighbor),
+                        TriInd(iy < yres - 1 ? 2 * i + xres * 2 : noNeighbor),
+                        TriInd(2 * i)));
                 *outFirst++ = t;
             }
         }

--- a/CDT/extras/VerifyTopology.h
+++ b/CDT/extras/VerifyTopology.h
@@ -28,7 +28,7 @@ namespace CDT
  * @tparam T type of vertex coordinates (e.g., float, double)
  * @tparam TNearPointLocator class providing locating near point for efficiently
  */
-template <typename T, typename TNearPointLocator = LocatorKDTree<T> >
+template <typename T, typename TNearPointLocator>
 inline bool verifyTopology(const CDT::Triangulation<T, TNearPointLocator>& cdt)
 {
     // Check if vertices' adjacent triangles contain vertex
@@ -75,12 +75,14 @@ inline bool verifyTopology(const CDT::Triangulation<T, TNearPointLocator>& cdt)
 }
 
 /// Check that each vertex has a neighbor triangle
-template <typename T, typename TNearPointLocator = LocatorKDTree<T> >
+template <typename T, typename TNearPointLocator>
 inline bool eachVertexHasNeighborTriangle(
     const CDT::Triangulation<T, TNearPointLocator>& cdt)
 {
-    for(const auto& vt : cdt.VertTrisInternal())
-        if(vt == noNeighbor)
+    const TriIndVec& vertTris = cdt.VertTrisInternal();
+    typedef TriIndVec::const_iterator TriIndCit;
+    for(TriIndCit it = vertTris.begin(); it != vertTris.end(); ++it)
+        if(*it == noNeighbor)
             return false;
     return true;
 }

--- a/CDT/include/CDTUtils.h
+++ b/CDT/include/CDTUtils.h
@@ -24,6 +24,15 @@ typedef char CDT_DONT_USE_BOOST_RTREE__was__replaced__with__CDT_USE_BOOST[-1];
 typedef char couldnt_parse_cxx_standard[-1]; ///< Error: couldn't parse standard
 #endif
 
+// 'noexcept' is only available since c++11 and its c++98 spelling 'throw()'
+// is in turn removed in c++20
+#ifdef CDT_CXX11_IS_SUPPORTED
+/// Portable 'noexcept': falls back to 'throw()' when only c++98 is available
+#define CDT_NOEXCEPT noexcept
+#else
+#define CDT_NOEXCEPT throw()
+#endif
+
 // Functions defined outside the class need to be 'inline'
 // if CDT is configured to be used as header-only library:
 // single-definition rule is violated otherwise

--- a/CDT/include/Triangulation.h
+++ b/CDT/include/Triangulation.h
@@ -150,6 +150,9 @@ public:
         , m_description(description)
         , m_srcLoc(srcLoc)
     {}
+    /// Destructor
+    virtual ~Error() CDT_NOEXCEPT
+    {}
     /// Get error description
     const std::string& description() const
     {

--- a/CDT/include/Triangulation.hpp
+++ b/CDT/include/Triangulation.hpp
@@ -1027,8 +1027,8 @@ void Triangulation<T, TNearPointLocator>::addSuperTriangle(const Box2d<T>& box)
     m_nTargetVerts = nSuperTriangleVertices;
     m_superGeomType = SuperGeometryType::SuperTriangle;
 
-    const V2d<T> center = {
-        (box.min.x + box.max.x) / T(2), (box.min.y + box.max.y) / T(2)};
+    const V2d<T> center(
+        (box.min.x + box.max.x) / T(2), (box.min.y + box.max.y) / T(2));
     const T w = box.max.x - box.min.x;
     const T h = box.max.y - box.min.y;
     T r = std::max(w, h); // incircle radius upper bound
@@ -1049,9 +1049,9 @@ void Triangulation<T, TNearPointLocator>::addSuperTriangle(const Box2d<T>& box)
     const T R = T(2) * r;                       // excircle radius
     const T cos_30_deg = T(0.8660254037844386); // note: (std::sqrt(3.0) / 2.0)
     const T shiftX = R * cos_30_deg;
-    const V2d<T> posV1 = {center.x - shiftX, center.y - r};
-    const V2d<T> posV2 = {center.x + shiftX, center.y - r};
-    const V2d<T> posV3 = {center.x, center.y + R};
+    const V2d<T> posV1(center.x - shiftX, center.y - r);
+    const V2d<T> posV2(center.x + shiftX, center.y - r);
+    const V2d<T> posV3(center.x, center.y + R);
     addNewVertex(posV1, TriInd(0));
     addNewVertex(posV2, TriInd(0));
     addNewVertex(posV3, TriInd(0));

--- a/CDT/tests/standards_check.cpp
+++ b/CDT/tests/standards_check.cpp
@@ -1,0 +1,69 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * @file
+ * Instantiates the public API so that it is compiled and not merely parsed.
+ *
+ * Compiled directly by the "C++ standards" CI job (not through CMake, which
+ * builds the Catch2 tests as c++17) to check that CDT builds with every
+ * supported standard. Keep this file c++98-compatible.
+ */
+
+#include <CDT.h>
+#include <InitializeWithGrid.h>
+#include <VerifyTopology.h>
+
+#include <cstdlib>
+#include <vector>
+
+namespace
+{
+
+template <typename T>
+bool checkCoordinateType()
+{
+    std::vector<CDT::V2d<T> > vv;
+    vv.push_back(CDT::V2d<T>(T(0), T(0)));
+    vv.push_back(CDT::V2d<T>(T(1), T(0)));
+    vv.push_back(CDT::V2d<T>(T(1), T(1)));
+    vv.push_back(CDT::V2d<T>(T(0), T(1)));
+    vv.push_back(CDT::V2d<T>(T(0), T(1))); // duplicate
+
+    std::vector<CDT::Edge> ee;
+    ee.push_back(CDT::Edge(CDT::VertInd(0), CDT::VertInd(2)));
+
+    const CDT::DuplicatesInfo di = CDT::RemoveDuplicatesAndRemapEdges(vv, ee);
+    if(di.duplicates.size() != 1)
+        return false;
+
+    CDT::Triangulation<T> cdt;
+    cdt.insertVertices(vv);
+    cdt.insertEdges(ee);
+    if(!CDT::verifyTopology(cdt))
+        return false;
+    if(!CDT::eachVertexHasNeighborTriangle(cdt))
+        return false;
+    cdt.eraseSuperTriangle();
+    if(cdt.triangles.empty())
+        return false;
+
+    CDT::Triangulation<T> grid;
+    CDT::initializeWithRegularGrid(T(0), T(1), T(0), T(1), 2, 2, grid);
+    if(!CDT::verifyTopology(grid))
+        return false;
+
+    return true;
+}
+
+} // namespace
+
+int main()
+{
+    if(!checkCoordinateType<float>())
+        return EXIT_FAILURE;
+    if(!checkCoordinateType<double>())
+        return EXIT_FAILURE;
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
C++98 compatibility is advertised in the README but has been broken since late 2023.
Nothing in CI ever compiles CDT with `-std=c++98`: the `use_boost=True` jobs exercise the Boost code paths but still compile as C++11/17, so this went unnoticed.
Last clean commit is ebbe76b, broken by 65be51a and 0b58dfd.

Changes:
- `Error`: declare a destructor with an explicit exception specification. In C++98 the destructor of `std::runtime_error` is `throw()` and the implicitly declared one is looser, which is ill-formed. Added `CDT_NOEXCEPT` because neither spelling works everywhere: `noexcept` is C++11 and `throw()` is removed in C++20.
- `VerifyTopology`: drop the default template arguments of the two function templates, which C++98 does not allow, and replace a range-based for loop. Both parameters are still deduced from the argument, so callers don't have to spell out the locator type.
- `Triangulation.hpp`, `InitializeWithGrid.h`: construct `V2d` and `Triangle` with their constructors instead of braces. Neither is an aggregate, so the braces were C++11 copy-list-initialization.
- `InitializeWithGrid.h`: the C++98 branch assigned the whole triangle vector where the C++11 branch assigned only `front()`. It was left behind when vertex-to-triangle storage changed to one triangle per vertex. Both branches are now the same line and cannot diverge again.
- New `tests/standards_check.cpp` that instantiates and exercises the public API, built by a new `CDT_ENABLE_STANDARDS_CHECK` CMake option. Only including the headers does not compile the `.hpp` template bodies, which is where half of these errors were.
- New CI job builds and runs it for C++98, 11, 14, 17, 20, 23 and 26, both header-only and as a compiled library. Boost comes from Conan like in the rest of CI. C++26 needs g++-14 and required no source changes.

The Catch2 tests cannot catch any of this: they are pinned to C++17.

Verified locally: all 7 standards in both modes build and run, Catch2 still passes (27/27, 29/29 with callbacks).