### PR TITLE
Do not run CI twice for branches with an open pull request

### DIFF
--- a/.github/workflows/ci_builds.yml
+++ b/.github/workflows/ci_builds.yml
@@ -1,6 +1,12 @@
 name: CI Builds
 
-on: [push, pull_request]
+# Only master on push: branches are covered by the pull_request event, which
+# additionally tests the result of merging into master. Running on every push
+# would build a branch with an open pull request twice.
+on:
+  push:
+    branches: [master]
+  pull_request:
 
 jobs:
   builds:


### PR DESCRIPTION
A branch pushed to this repository with an open pull request triggers both the `push` and the `pull_request` event, so every commit was built twice. On #218 both runs started 3 seconds apart for the same commit, one on `refs/heads/fix-cxx98-and-cxx26` and one on `refs/pull/218/merge`, which doubled the runner minutes of the whole matrix.

Restrict `push` to master. Branches keep their CI through the `pull_request` event, which additionally tests the result of merging into master rather than just the branch tip. Fork pull requests are unaffected: they only ever trigger `pull_request`.

Note that pushing a branch without an open pull request no longer runs CI. `workflow_dispatch` can be added later if a manual trigger is wanted.
