### PR TITLE
Automatically publish documentation to GitHub Pages

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,64 @@
+name: Documentation
+
+# Same rationale as in ci_builds.yml: master on push, branches via pull_request.
+# Pull requests only check that the docs still build, master also publishes them.
+on:
+  push:
+    branches: [master]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Never let two deployments to GitHub Pages run at the same time.
+concurrency:
+  group: github-pages
+  cancel-in-progress: false
+
+env:
+  # Keep in sync with the Doxygen version the docs were last generated with
+  DOXYGEN_VERSION: "1.13.2"
+
+jobs:
+  build:
+    name: Generate Doxygen documentation
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install Graphviz
+      run: sudo apt-get update && sudo apt-get install --yes graphviz
+
+    - name: Install Doxygen
+      run: |
+        tag="Release_${DOXYGEN_VERSION//./_}"
+        url="https://github.com/doxygen/doxygen/releases/download/$tag/doxygen-$DOXYGEN_VERSION.linux.bin.tar.gz"
+        curl --fail --silent --show-error --location "$url" | sudo tar xz -C /opt
+        echo "/opt/doxygen-$DOXYGEN_VERSION/bin" >> "$GITHUB_PATH"
+
+    - name: Configure
+      run: cmake -S CDT -B build
+
+    - name: Generate documentation
+      run: cmake --build build --target CDT-docs
+
+    - name: Upload GitHub Pages artifact
+      uses: actions/upload-pages-artifact@v3
+      with:
+        path: build/docs/html
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-24.04
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+    - name: Deploy
+      id: deployment
+      uses: actions/deploy-pages@v4

--- a/CDT/CMakeLists.txt
+++ b/CDT/CMakeLists.txt
@@ -239,7 +239,6 @@ if(DOXYGEN_FOUND)
         ${CDT_DOXYGEN_AWESOME_DIRECTORY}/doxygen-awesome-darkmode-toggle.js
         ${CDT_DOXYGEN_AWESOME_DIRECTORY}/doxygen-awesome-fragment-copy-button.js
         ${CDT_DOXYGEN_AWESOME_DIRECTORY}/doxygen-awesome-paragraph-link.js
-        ${CDT_DOXYGEN_AWESOME_DIRECTORY}/toggle-alternative-theme.js
     )
     set(DOXYGEN_LAYOUT_FILE ${CDT_DOCS_DIRECTORY}/doxygen-custom/DoxygenLayout.xml)
     # this target will only be built if specifically asked to.

--- a/docs/doxygen-custom/header.html
+++ b/docs/doxygen-custom/header.html
@@ -34,7 +34,6 @@
 <script type="text/javascript" src="$relpath^doxygen-awesome-darkmode-toggle.js"></script>
 <script type="text/javascript" src="$relpath^doxygen-awesome-fragment-copy-button.js"></script>
 <script type="text/javascript" src="$relpath^doxygen-awesome-paragraph-link.js"></script>
-<script type="text/javascript" src="$relpath^toggle-alternative-theme.js"></script>
 <script type="text/javascript">
     DoxygenAwesomeFragmentCopyButton.init()
     DoxygenAwesomeDarkModeToggle.init()


### PR DESCRIPTION
Documentation is currently generated and pushed to the `gh-pages` branch by hand. This adds a workflow that does it on every merge to master.

## Changes

- **`.github/workflows/documentation.yml`**: builds the `CDT-docs` target and deploys the result with the official `actions/upload-pages-artifact` + `actions/deploy-pages`.
  - Doxygen is pinned to 1.13.2 (the version the currently published docs were generated with), installed from the official release tarball; Graphviz comes from apt so the inheritance/collaboration graphs are still rendered.
  - Triggers follow the same convention as `ci_builds.yml`: `push` on master plus `pull_request`, so no branch is built twice. Pull requests only check that the documentation still builds, the deploy job is skipped for them.
  - A `github-pages` concurrency group prevents two deployments from overlapping.
- **Removed the reference to `toggle-alternative-theme.js`** from `HTML_EXTRA_FILES` and `header.html`. That script is a demo-only widget from doxygen-awesome-css's own `doc/` folder (it lets their site preview theme variants), it is not part of the theme distribution and was never in this repo. Nothing on the CDT pages calls into it, so Doxygen was reporting `error: Extra file ... does not exist!` and the published pages were requesting a script that 404s.

## Notes

The Pages source has been switched to "GitHub Actions" in the repository settings, so the first deployment happens when this is merged. The site keeps serving the old `gh-pages` content until then; that branch can be deleted once the switchover is confirmed.

## Testing

Generated the documentation locally with Doxygen 1.13.2 and Graphviz using the exact commands from the workflow: the target builds, graphs are rendered, no Doxygen errors remain, and the generated HTML no longer references the missing script.