### PR TITLE
Fix search box overlapping the title in generated documentation

### DIFF
--- a/CDT/CMakeLists.txt
+++ b/CDT/CMakeLists.txt
@@ -221,6 +221,9 @@ if(DOXYGEN_FOUND)
     set(DOXYGEN_IMAGE_PATH ${CDT_DOCS_DIRECTORY}/images)
 
     set(DOXYGEN_GENERATE_TREEVIEW YES)
+    # Keep the index enabled so the search box stays in the navigation area
+    # instead of overlapping the title (CMake defaults DISABLE_INDEX to YES).
+    set(DOXYGEN_DISABLE_INDEX NO)
     set(CDT_DOXYGEN_AWESOME_DIRECTORY ${CDT_DOCS_DIRECTORY}/doxygen-custom/doxygen-awesome)
     set(DOXYGEN_HTML_EXTRA_STYLESHEET
         ${CDT_DOXYGEN_AWESOME_DIRECTORY}/doxygen-awesome.css


### PR DESCRIPTION
Follow-up to #221.

CMake's Doxyfile template defaults `DISABLE_INDEX` to `YES`, which makes Doxygen render the search box inside the title-area table, right next to the project name and brief. In the doxygen-awesome sidebar-only layout the sidebar is a fixed 335px wide, so the search box and the project name/brief overlap in the top-left corner.

The doxygen-awesome sidebar-only layout (and its reference site) expect `DISABLE_INDEX = NO`, which keeps the search box in the navigation area below the title. Setting it fixes the overlap; the project brief then spans the full sidebar width and no longer collides with the search box.

## Testing

Generated the documentation locally with Doxygen 1.13.2 and Graphviz: the search box is no longer in the title area, the brief renders cleanly above it, and no extra vertical gap is introduced (the theme's default `--top-height` is enough).