### PR TITLE
Fix documentation always using a black background in dark system theme

### DIFF
--- a/CDT/CMakeLists.txt
+++ b/CDT/CMakeLists.txt
@@ -224,6 +224,8 @@ if(DOXYGEN_FOUND)
     # Keep the index enabled so the search box stays in the navigation area
     # instead of overlapping the title (CMake defaults DISABLE_INDEX to YES).
     set(DOXYGEN_DISABLE_INDEX NO)
+    # Disable Doxygen's own dark mode: it overrides doxygen-awesome's themes.
+    set(DOXYGEN_HTML_COLORSTYLE LIGHT)
     set(CDT_DOXYGEN_AWESOME_DIRECTORY ${CDT_DOCS_DIRECTORY}/doxygen-custom/doxygen-awesome)
     set(DOXYGEN_HTML_EXTRA_STYLESHEET
         ${CDT_DOXYGEN_AWESOME_DIRECTORY}/doxygen-awesome.css


### PR DESCRIPTION
## Problem

On a device whose system theme is dark (typically a phone), the generated documentation always had a **black** page background. Switching the doxygen-awesome light/dark toggle only changed doxygen-awesome-specific colors, most visibly code fragments — the page itself stayed black.

## Cause

CMake defaults `HTML_COLORSTYLE` to `AUTO_LIGHT`, so Doxygen ships its own dark theme in `doxygen.css`:

```css
@media (prefers-color-scheme: dark) {
  html:not(.dark-mode) { color-scheme: dark; --page-background-color: black; ... }
}
```

doxygen-awesome uses the opposite marker class: it sets `light-mode` on `<html>` for light and `dark-mode` for dark. In light mode the page is therefore `light-mode`, so Doxygen's `html:not(.dark-mode)` rule still matches, and at specificity `(0,1,1)` it outranks doxygen-awesome's `html {...}` defaults `(0,0,1)` regardless of stylesheet order — forcing `--page-background-color: black`.

Only the shared variable names were affected. Code fragments use `--fragment-background`, which is doxygen-awesome-only (Doxygen calls it `--fragment-background-color`), so they alone kept following the toggle. Desktops were unaffected because the media query requires a dark system preference.

## Fix

Set `HTML_COLORSTYLE = LIGHT`, as doxygen-awesome requires for Doxygen >= 1.9.5, and let doxygen-awesome own both themes.

## Verification

Built the docs locally with Doxygen 1.13.2 (the version pinned in CI) before and after, and read computed styles in a headless browser with a dark system theme:

| State (dark system theme) | Before | After |
| --- | --- | --- |
| Light mode selected | body `rgb(0,0,0)`, `color-scheme: dark` | body `rgb(255,255,255)`, `color-scheme: normal` |
| Dark mode (default) | `#1C1D1F` | `#1C1D1F` — unchanged |
| Light system theme | white | white — unchanged |

`LIGHT` also makes Doxygen inline literal colors instead of CSS variables in `doxygen.css`, `tabs.css`, `navtree.css`, `search.css` and `dynsections.js`. Every inlined value is the light one, which is what dark mode already resolved to (Doxygen's dark variables never applied under `.dark-mode`), and doxygen-awesome overrides the affected rules anyway.